### PR TITLE
query or search for entity id boundaries

### DIFF
--- a/src/main/java/com/bullhornsdk/data/api/BullhornData.java
+++ b/src/main/java/com/bullhornsdk/data/api/BullhornData.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.bullhornsdk.data.api.helper.EntityIdBoundaries;
 import com.bullhornsdk.data.model.entity.core.type.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -602,5 +603,25 @@ public interface BullhornData {
 	 * @return the restApiSession
 	 */
 	public RestApiSession getRestApiSession();
+
+
+	/**
+	 * Query for entity id boundaries of active entities (isDeleted is false)
+	 *
+	 * @param entityClass       Class of entity
+	 * @param <T>               Class extending QueryEntity
+	 * @return Range with minimum and maximum id
+	 */
+	public <T extends QueryEntity> EntityIdBoundaries queryForIdBoundaries(Class<T> entityClass);
+
+
+	/**
+	 * Search for entity id boundaries of active entities (isDeleted is false)
+	 *
+	 * @param entityClass       Class of entity
+	 * @param <T>               Class extending SearchEntity
+	 * @return Range with minimum and maximum id
+	 */
+	public <T extends SearchEntity> EntityIdBoundaries searchForIdBoundaries(Class<T> entityClass);
 
 }

--- a/src/main/java/com/bullhornsdk/data/api/helper/EntityIdBoundaries.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/EntityIdBoundaries.java
@@ -1,0 +1,51 @@
+package com.bullhornsdk.data.api.helper;
+
+/**
+ * Entity id boundaries
+ *
+ */
+public class EntityIdBoundaries {
+
+    private Integer min;
+    private Integer max;
+    private Class entityClass;
+
+    public EntityIdBoundaries(){
+
+    }
+
+    public EntityIdBoundaries(Integer min, Integer max, Class entityClass) {
+        this.min = min;
+        this.max = max;
+        this.entityClass = entityClass;
+    }
+
+    public Integer getMin() {
+        return min;
+    }
+
+    public void setMin(Integer min) {
+        this.min = min;
+    }
+
+    public Integer getMax() {
+        return max;
+    }
+
+    public void setMax(Integer max) {
+        this.max = max;
+    }
+
+    public Class getEntityClass() {
+        return entityClass;
+    }
+
+    public void setEntityClass(Class entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    @Override
+    public String toString() {
+        return "Entity id range [" + min + " - " + max + "] for " + entityClass.getSimpleName();
+    }
+}

--- a/src/main/java/com/bullhornsdk/data/api/mock/MockBullhornData.groovy
+++ b/src/main/java/com/bullhornsdk/data/api/mock/MockBullhornData.groovy
@@ -1,6 +1,7 @@
 package com.bullhornsdk.data.api.mock
 
 import com.bullhornsdk.data.api.BullhornData
+import com.bullhornsdk.data.api.helper.EntityIdBoundaries
 import com.bullhornsdk.data.api.helper.RestApiSession
 import com.bullhornsdk.data.api.helper.RestErrorHandler
 import com.bullhornsdk.data.exception.RestApiException
@@ -11,6 +12,8 @@ import com.bullhornsdk.data.model.entity.core.type.*
 import com.bullhornsdk.data.model.entity.meta.MetaData
 import com.bullhornsdk.data.model.enums.MetaParameter
 import com.bullhornsdk.data.model.parameter.*
+import com.bullhornsdk.data.model.parameter.standard.StandardQueryParams
+import com.bullhornsdk.data.model.parameter.standard.StandardSearchParams
 import com.bullhornsdk.data.model.response.crud.CreateResponse
 import com.bullhornsdk.data.model.response.crud.CrudResponse
 import com.bullhornsdk.data.model.response.crud.UpdateResponse
@@ -333,4 +336,17 @@ public class MockBullhornData implements BullhornData {
 		return this.restSession;
 	}
 
+	@Override
+	def <T extends QueryEntity> EntityIdBoundaries queryForIdBoundaries(Class<T> entityClass) {
+		List<T> entities = mockDataHandler.queryForList(entityClass, "id>0", ["id"].toSet(), StandardQueryParams.instance)
+		List<Integer> ids = entities.collect { it.id }
+		new EntityIdBoundaries(ids.min(), ids.max(), entityClass)
+	}
+
+	@Override
+	def <T extends SearchEntity> EntityIdBoundaries searchForIdBoundaries(Class<T> entityClass) {
+		List<T> entities = mockDataHandler.searchForList(entityClass, "id>0", ["id"].toSet(), StandardSearchParams.instance)
+		List<Integer> ids = entities.collect { it.id }
+		new EntityIdBoundaries(ids.min(), ids.max(), entityClass)
+	}
 }


### PR DESCRIPTION
Query for the minimum and maximum id's of a QueryEntity (for instance JobOrder).
Search for the minimum and maximum id's of a SearchEntity (for instance Candidate).