### PR TITLE
Create list wrapper class for "/options/" calls

### DIFF
--- a/src/main/java/com/bullhornsdk/data/api/BullhornData.java
+++ b/src/main/java/com/bullhornsdk/data/api/BullhornData.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.bullhornsdk.data.model.parameter.*;
+import com.bullhornsdk.data.model.response.list.OptionListWrapper;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.bullhornsdk.data.api.helper.EntityIdBoundaries;
@@ -30,14 +32,6 @@ import com.bullhornsdk.data.model.enums.EventType;
 import com.bullhornsdk.data.model.enums.MetaParameter;
 import com.bullhornsdk.data.model.enums.SettingsFields;
 import com.bullhornsdk.data.model.file.FileMeta;
-import com.bullhornsdk.data.model.parameter.AssociationParams;
-import com.bullhornsdk.data.model.parameter.CorpNotesParams;
-import com.bullhornsdk.data.model.parameter.FastFindParams;
-import com.bullhornsdk.data.model.parameter.FileParams;
-import com.bullhornsdk.data.model.parameter.QueryParams;
-import com.bullhornsdk.data.model.parameter.ResumeFileParseParams;
-import com.bullhornsdk.data.model.parameter.ResumeTextParseParams;
-import com.bullhornsdk.data.model.parameter.SearchParams;
 import com.bullhornsdk.data.model.parameter.standard.ParamFactory;
 import com.bullhornsdk.data.model.response.crud.CrudResponse;
 import com.bullhornsdk.data.model.response.edithistory.EditHistoryListWrapper;
@@ -281,6 +275,18 @@ public interface BullhornData {
 	 * @return a DeleteResponse with deleted entity information
 	 */
 	public <C extends CrudResponse, T extends DeleteEntity> C deleteEntity(Class<T> type, Integer id);
+
+
+    /**
+     *
+     * Returns the Options for passed in type.
+     *
+     * @param optionsType  a BullhornEntity
+     * @param params specifies start, count, filter, and (in case of a specific State call) country
+     *
+     * @return an OptionListWrapper with the list of options from which one could choose
+     */
+    public <T extends BullhornEntity> OptionListWrapper getOptions(OptionParams params, Class<T> optionsType);
 
 	/**
 	 * 

--- a/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
+++ b/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
@@ -14,6 +14,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import com.bullhornsdk.data.model.entity.meta.Option;
+import com.bullhornsdk.data.model.parameter.*;
+import com.bullhornsdk.data.model.response.list.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.json.JSONException;
@@ -72,15 +75,6 @@ import com.bullhornsdk.data.model.enums.EventType;
 import com.bullhornsdk.data.model.enums.MetaParameter;
 import com.bullhornsdk.data.model.enums.SettingsFields;
 import com.bullhornsdk.data.model.file.FileMeta;
-import com.bullhornsdk.data.model.parameter.AssociationParams;
-import com.bullhornsdk.data.model.parameter.CorpNotesParams;
-import com.bullhornsdk.data.model.parameter.EntityParams;
-import com.bullhornsdk.data.model.parameter.FastFindParams;
-import com.bullhornsdk.data.model.parameter.FileParams;
-import com.bullhornsdk.data.model.parameter.QueryParams;
-import com.bullhornsdk.data.model.parameter.ResumeFileParseParams;
-import com.bullhornsdk.data.model.parameter.ResumeTextParseParams;
-import com.bullhornsdk.data.model.parameter.SearchParams;
 import com.bullhornsdk.data.model.parameter.standard.ParamFactory;
 import com.bullhornsdk.data.model.parameter.standard.StandardQueryParams;
 import com.bullhornsdk.data.model.parameter.standard.StandardSearchParams;
@@ -103,10 +97,6 @@ import com.bullhornsdk.data.model.response.file.standard.StandardEntityMetaFiles
 import com.bullhornsdk.data.model.response.file.standard.StandardFileApiResponse;
 import com.bullhornsdk.data.model.response.file.standard.StandardFileContent;
 import com.bullhornsdk.data.model.response.file.standard.StandardFileWrapper;
-import com.bullhornsdk.data.model.response.list.FastFindListWrapper;
-import com.bullhornsdk.data.model.response.list.ListWrapper;
-import com.bullhornsdk.data.model.response.list.NoteListWrapper;
-import com.bullhornsdk.data.model.response.list.StandardListWrapper;
 import com.bullhornsdk.data.model.response.resume.ParsedResume;
 import com.bullhornsdk.data.model.response.resume.standard.StandardParsedResume;
 import com.bullhornsdk.data.model.response.subscribe.SubscribeToEventsResponse;
@@ -325,6 +315,11 @@ public class StandardBullhornData implements BullhornData {
     @Override
     public <C extends CrudResponse, T extends DeleteEntity> C deleteEntity(Class<T> type, Integer id) {
         return this.handleDeleteEntity(type, id);
+    }
+
+    @Override
+    public <T extends BullhornEntity> OptionListWrapper getOptions(OptionParams params, Class<T> optionsType){
+        return this.handleGetOptions(params, optionsType);
     }
 
     /**
@@ -1156,6 +1151,25 @@ public class StandardBullhornData implements BullhornData {
         String url = restUrlFactory.assembleEntityUrlForMeta(privateLabelId);
 
         MetaData<T> response = this.performGetRequest(url, StandardMetaData.class, uriVariables);
+
+        return response;
+
+    }
+
+    /**
+     * Makes the "options" api call
+     * <p>
+     * HttpMethod: GET
+     *
+     * @param params the variables to inject into the url.
+     * @return the Options list
+     */
+    protected <T extends BullhornEntity> OptionListWrapper handleGetOptions(OptionParams params, Class<T> optionType) {
+        String url = restUrlFactory.assembleEntityUrlForOptions(params);
+
+        Map<String, String> uriVariables = restUriVariablesFactory.getUriVariablesForOptions(BullhornEntityInfo.getTypesRestEntityName(optionType));
+
+        OptionListWrapper response = this.performGetRequest(url, OptionListWrapper.class, uriVariables);
 
         return response;
 

--- a/src/main/java/com/bullhornsdk/data/api/helper/RestUriVariablesFactory.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/RestUriVariablesFactory.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.bullhornsdk.data.model.parameter.*;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,15 +19,6 @@ import com.bullhornsdk.data.model.enums.EntityEventType;
 import com.bullhornsdk.data.model.enums.EventType;
 import com.bullhornsdk.data.model.enums.MetaParameter;
 import com.bullhornsdk.data.model.file.FileMeta;
-import com.bullhornsdk.data.model.parameter.AssociationParams;
-import com.bullhornsdk.data.model.parameter.CorpNotesParams;
-import com.bullhornsdk.data.model.parameter.EntityParams;
-import com.bullhornsdk.data.model.parameter.FastFindParams;
-import com.bullhornsdk.data.model.parameter.FileParams;
-import com.bullhornsdk.data.model.parameter.QueryParams;
-import com.bullhornsdk.data.model.parameter.ResumeFileParseParams;
-import com.bullhornsdk.data.model.parameter.ResumeTextParseParams;
-import com.bullhornsdk.data.model.parameter.SearchParams;
 import com.bullhornsdk.data.model.parameter.standard.ParamFactory;
 
 public class RestUriVariablesFactory {
@@ -38,11 +30,11 @@ public class RestUriVariablesFactory {
 	// url parameter names
 	private static final String BH_REST_TOKEN = "bhRestToken";
 	private static final String ENTITY_TYPE = "entityType";
-	private static final String FIELDS = "fields";
+    private static final String FIELDS = "fields";
 	private static final String META = "meta";
 	private static final String WHERE = "where";
 	private static final String QUERY = "query";
-	private static final String FORMAT = "format";
+    private static final String FORMAT = "format";
 	private static final String ENTITY_ID = "entityId";
 	private static final String FILE_ID = "fileId";
 	private static final String EXTERNAL_ID = "externalID";
@@ -179,6 +171,21 @@ public class RestUriVariablesFactory {
 		uriVariables.put(ID, id.toString());
 		return uriVariables;
 	}
+
+    /**
+     * Returns the uri variables needed for a "options" GET request
+     *
+     * @param entityInfo
+     * @return all uriVariables needed for the api call
+     */
+    public <T extends BullhornEntity> Map<String, String> getUriVariablesForOptions(BullhornEntityInfo entityInfo) {
+
+        Map<String, String> uriVariables = new LinkedHashMap<>();
+        String bhRestToken = bullhornApiRest.getBhRestToken();
+        uriVariables.put(BH_REST_TOKEN, bhRestToken);
+        uriVariables.put(ENTITY_TYPE, entityInfo.getName());
+        return uriVariables;
+    }
 
 	/**
 	 * Returns the uri variables needed for the "entity" PUT request.

--- a/src/main/java/com/bullhornsdk/data/api/helper/RestUrlFactory.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/RestUrlFactory.java
@@ -6,6 +6,7 @@ import com.bullhornsdk.data.model.parameter.CorpNotesParams;
 import com.bullhornsdk.data.model.parameter.EntityParams;
 import com.bullhornsdk.data.model.parameter.FastFindParams;
 import com.bullhornsdk.data.model.parameter.FileParams;
+import com.bullhornsdk.data.model.parameter.OptionParams;
 import com.bullhornsdk.data.model.parameter.QueryParams;
 import com.bullhornsdk.data.model.parameter.ResumeFileParseParams;
 import com.bullhornsdk.data.model.parameter.ResumeTextParseParams;
@@ -98,6 +99,10 @@ public class RestUrlFactory {
         }
 
         return restUrl + "meta/{entityType}?fields={fields}&BhRestToken={bhRestToken}&meta={meta}&privateLabelId={privateLabelId}";
+    }
+
+    public String assembleEntityUrlForOptions(OptionParams params) {
+        return restUrl + "options/{optionType}?BhRestToken={bhRestToken}&" + params.getUrlString();
     }
 
     /**

--- a/src/main/java/com/bullhornsdk/data/api/mock/MockBullhornData.groovy
+++ b/src/main/java/com/bullhornsdk/data/api/mock/MockBullhornData.groovy
@@ -25,6 +25,7 @@ import com.bullhornsdk.data.model.response.file.FileContent
 import com.bullhornsdk.data.model.response.file.FileWrapper
 import com.bullhornsdk.data.model.response.list.FastFindListWrapper
 import com.bullhornsdk.data.model.response.list.ListWrapper
+import com.bullhornsdk.data.model.response.list.OptionListWrapper
 import com.bullhornsdk.data.model.response.resume.ParsedResume
 import com.bullhornsdk.data.model.response.subscribe.SubscribeToEventsResponse
 import com.bullhornsdk.data.model.response.subscribe.standard.StandardSubscribeToEventsResponse
@@ -176,6 +177,11 @@ public class MockBullhornData implements BullhornData {
     @Override
     public <C extends CrudResponse, T extends DeleteEntity> C deleteEntity(Class<T> type, Integer id) {
         return mockDataHandler.deleteEntity(type, id);
+    }
+
+    @Override
+    public <T extends BullhornEntity> OptionListWrapper getOptions(OptionParams params, Class<T> optionsType) {
+        return mockDataHandler.getOptions(params, optionsType);
     }
 
     @Override

--- a/src/main/java/com/bullhornsdk/data/api/mock/MockDataHandler.groovy
+++ b/src/main/java/com/bullhornsdk/data/api/mock/MockDataHandler.groovy
@@ -8,6 +8,7 @@ import com.bullhornsdk.data.model.entity.core.standard.*
 import com.bullhornsdk.data.model.entity.core.type.*
 import com.bullhornsdk.data.model.entity.embedded.OneToMany
 import com.bullhornsdk.data.model.entity.meta.MetaData
+import com.bullhornsdk.data.model.entity.meta.Option
 import com.bullhornsdk.data.model.enums.MetaParameter
 import com.bullhornsdk.data.model.enums.SettingsFields
 import com.bullhornsdk.data.model.parameter.*
@@ -32,6 +33,7 @@ import com.bullhornsdk.data.model.file.standard.StandardFileMeta
 import com.bullhornsdk.data.model.response.file.standard.StandardFileWrapper
 import com.bullhornsdk.data.model.response.list.FastFindListWrapper
 import com.bullhornsdk.data.model.response.list.ListWrapper
+import com.bullhornsdk.data.model.response.list.OptionListWrapper
 import com.bullhornsdk.data.model.response.list.StandardListWrapper
 import com.bullhornsdk.data.model.response.resume.ParsedResume
 import com.bullhornsdk.data.model.response.resume.standard.StandardParsedResume
@@ -62,6 +64,7 @@ public class MockDataHandler {
 	private final MockDataLoader mockDataLoader;
 	private Map<Class<? extends BullhornEntity>, Map<Integer, ? extends BullhornEntity>> restEntityMap;
 	private Map<Class<? extends BullhornEntity>, MetaData<?>> restMetaDataMap;
+    private Map<Class<? extends BullhornEntity>, OptionListWrapper> restOptionMap;
 	private Map<Class<? extends SearchEntity>, List<MockSearchField>> searchFieldsMap;
 	private Map<String,Closure> queryClosures = new HashMap<String,Closure>();
 	private List<FastFindResult> fastFindResults;
@@ -76,6 +79,7 @@ public class MockDataHandler {
 		this.mockDataLoader = new MockDataLoader();
 		this.restEntityMap = mockDataLoader.getEntityTestData();
 		this.restMetaDataMap = mockDataLoader.getMetaTestData();
+        this.restOptionMap = mockDataLoader.getOptionTestData();
 		this.searchFieldsMap = mockDataLoader.getSearchFields();
 		this.fastFindResults = mockDataLoader.getFastFindResults();
 		this.editHistoryList = mockDataLoader.getEditHistoryList();
@@ -90,6 +94,7 @@ public class MockDataHandler {
 	public void refreshTestData(){
 		this.restEntityMap = mockDataLoader.reloadEntityDataFromCache();
 		this.restMetaDataMap = mockDataLoader.reloadMetaDataFromCache();
+        this.restOptionMap = mockDataLoader.reloadOptionsFromCache();
 	}
 
 	/**
@@ -430,6 +435,16 @@ public class MockDataHandler {
 		Set<String> verifiedAndModifiedFields = checkAndMofifyFields(fieldSet,type);
 		return restMetaDataMap.get(type);
 	}
+
+/**
+ * Returns the options data. Ignores params since these were set in the test calls
+ * @param optionsType
+ * @param params
+ * @return
+ */
+    public <T extends BullhornEntity> OptionListWrapper getOptions(OptionParams params, Class<T> optionsType){
+        return restOptionMap.get(optionsType);
+    }
 
 	/**
 	 * Returns the settings data. 

--- a/src/main/java/com/bullhornsdk/data/model/parameter/OptionParams.java
+++ b/src/main/java/com/bullhornsdk/data/model/parameter/OptionParams.java
@@ -1,0 +1,46 @@
+package com.bullhornsdk.data.model.parameter;
+
+/**
+ * Optional parameters for the "query" api call.
+ *
+ * @author magnus.palm
+ */
+public interface OptionParams extends RequestParameters {
+
+    /**
+     * Limit on the number of entities to return. Default is 15.
+     */
+    public Integer getCount();
+
+    /**
+     * Limit on the number of entities to return. Default is 15.
+     *
+     * @param count
+     */
+    public void setCount(Integer count);
+
+    /**
+     * From the set of matched results, return item numbers start through (start + count)
+     */
+    public Integer getStart();
+
+    /**
+     * From the set of matched results, return item numbers start through (start + count)
+     *
+     * @param start
+     */
+    public void setStart(Integer start);
+
+    /**
+     * Filter on the label, prefix with an asterisk (*) to find word begins.
+     */
+    public String getFilter();
+
+    /**
+     * Filter on the label, prefix with an asterisk (*) to find word begins.
+     *
+     * @param filter
+     */
+    public void setFilter(String filter);
+
+}

--- a/src/main/java/com/bullhornsdk/data/model/parameter/StateOptionParams.java
+++ b/src/main/java/com/bullhornsdk/data/model/parameter/StateOptionParams.java
@@ -1,0 +1,24 @@
+package com.bullhornsdk.data.model.parameter;
+
+/**
+ * Optional parameters for the "query" api call.
+ *
+ * @author magnus.palm
+ */
+public interface StateOptionParams extends OptionParams {
+
+    /**
+     * Optional “country” to restrict to states within that country, two-character ISO country code. Only one
+     * country may be selected for each call.
+     */
+    public String getCountry();
+
+    /**
+     * Optional “country” to restrict to states within that country, two-character ISO country code. Only one
+     * country may be selected for each call.
+     *
+     * @param country
+     */
+    public void setCountry(String country);
+
+}

--- a/src/main/java/com/bullhornsdk/data/model/parameter/standard/StandardOptionParams.java
+++ b/src/main/java/com/bullhornsdk/data/model/parameter/standard/StandardOptionParams.java
@@ -1,0 +1,100 @@
+package com.bullhornsdk.data.model.parameter.standard;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.bullhornsdk.data.model.parameter.OptionParams;
+
+public class StandardOptionParams implements OptionParams {
+
+    private Integer count;
+
+    private Integer start;
+
+    private String filter;
+
+    private StandardOptionParams() {
+        super();
+
+        this.count = 20;
+        this.start = null;
+        this.filter = null;
+    }
+
+    public static StandardOptionParams getInstance() {
+        StandardOptionParams params = new StandardOptionParams();
+
+        return params;
+    }
+
+    @Override
+    public Integer getCount() {
+        return count;
+    }
+
+    /**
+     * Limit on the number of entities to return. Default is 20.
+     *
+     * @param count
+     */
+
+    @Override
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    @Override
+    public Integer getStart() {
+        return start;
+    }
+
+    @Override
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    @Override
+    public String getFilter() {
+        return filter;
+    }
+
+    @Override
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public String getUrlString() {
+        StringBuilder url = new StringBuilder();
+
+        if (count != null) {
+            url.append("&count={count}");
+        }
+        if (start != null) {
+            url.append("&start={start}");
+        }
+        if (filter != null) {
+            url.append("&filter={filter}");
+        }
+
+        return url.toString();
+    }
+
+    @Override
+    public Map<String, String> getParameterMap() {
+        Map<String, String> uriVariables = new LinkedHashMap<String, String>();
+
+        if (count != null) {
+            uriVariables.put("count", "" + count);
+        }
+        if (start != null) {
+            uriVariables.put("start", "" + start);
+        }
+        if (filter != null) {
+            uriVariables.put("filter", filter);
+        }
+
+        return uriVariables;
+    }
+
+}

--- a/src/main/java/com/bullhornsdk/data/model/parameter/standard/StandardStateOptionParams.java
+++ b/src/main/java/com/bullhornsdk/data/model/parameter/standard/StandardStateOptionParams.java
@@ -1,0 +1,119 @@
+package com.bullhornsdk.data.model.parameter.standard;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.bullhornsdk.data.model.parameter.StateOptionParams;
+
+public class StandardStateOptionParams implements StateOptionParams {
+
+    private Integer count;
+
+    private Integer start;
+
+    private String filter;
+
+    private String country;
+
+    private StandardStateOptionParams() {
+        super();
+
+        this.count = 20;
+        this.start = null;
+        this.filter = null;
+        this.country = null;
+    }
+
+    public static StandardStateOptionParams getInstance() {
+        StandardStateOptionParams params = new StandardStateOptionParams();
+
+        return params;
+    }
+
+    @Override
+    public Integer getCount() {
+        return count;
+    }
+
+    /**
+     * Limit on the number of entities to return. Default is 20.
+     *
+     * @param count
+     */
+
+    @Override
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    @Override
+    public Integer getStart() {
+        return start;
+    }
+
+    @Override
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    @Override
+    public String getFilter() {
+        return filter;
+    }
+
+    @Override
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public String getCountry() {
+        return country;
+    }
+
+    @Override
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    @Override
+    public String getUrlString() {
+        StringBuilder url = new StringBuilder();
+
+        if (count != null) {
+            url.append("&count={count}");
+        }
+        if (start != null) {
+            url.append("&start={start}");
+        }
+        if (filter != null) {
+            url.append("&filter={filter}");
+        }
+        if (country != null) {
+            url.append("&country={country}");
+        }
+
+        return url.toString();
+    }
+
+    @Override
+    public Map<String, String> getParameterMap() {
+        Map<String, String> uriVariables = new LinkedHashMap<String, String>();
+
+        if (count != null) {
+            uriVariables.put("count", "" + count);
+        }
+        if (start != null) {
+            uriVariables.put("start", "" + start);
+        }
+        if (filter != null) {
+            uriVariables.put("filter", filter);
+        }
+        if (country != null) {
+            uriVariables.put("country", country);
+        }
+
+        return uriVariables;
+    }
+
+}

--- a/src/main/java/com/bullhornsdk/data/model/response/list/OptionListWrapper
+++ b/src/main/java/com/bullhornsdk/data/model/response/list/OptionListWrapper
@@ -1,0 +1,66 @@
+package com.bullhornsdk.data.model.response.list;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.bullhornsdk.data.model.entity.meta.Option;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "data" })
+public class OptionListWrapper {
+
+	@JsonProperty("data")
+	private List<Option> data = new ArrayList<Option>();
+	
+	private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+	
+	public OptionListWrapper() {
+		super();
+	}
+
+	public OptionListWrapper(Option[] data) {
+		super();
+		this.data = Arrays.asList(data);
+	}
+
+	
+	@JsonProperty("data")
+	public List<Option> getData() {
+		return data;
+	}
+
+	
+	@JsonProperty("data")
+	public void setData(Option[] data) {
+		this.data = Arrays.asList(data);
+	}
+	
+	@JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+    
+    public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("Options {\ndata=");
+		builder.append(data);
+		builder.append(", \nadditionalProperties=");
+		builder.append(additionalProperties);
+		builder.append("\n}");
+		return builder.toString();
+	}
+  
+}

--- a/src/main/java/com/bullhornsdk/data/model/response/list/OptionListWrapper.java
+++ b/src/main/java/com/bullhornsdk/data/model/response/list/OptionListWrapper.java
@@ -1,0 +1,66 @@
+package com.bullhornsdk.data.model.response.list;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.bullhornsdk.data.model.entity.meta.Option;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "data" })
+public class OptionListWrapper {
+
+    @JsonProperty("data")
+    private List<Option> data = new ArrayList<Option>();
+
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    public OptionListWrapper() {
+        super();
+    }
+
+    public OptionListWrapper(Option[] data) {
+        super();
+        this.data = Arrays.asList(data);
+    }
+
+
+    @JsonProperty("data")
+    public List<Option> getData() {
+        return data;
+    }
+
+
+    @JsonProperty("data")
+    public void setData(Option[] data) {
+        this.data = Arrays.asList(data);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Options {\ndata=");
+        builder.append(data);
+        builder.append(", \nadditionalProperties=");
+        builder.append(additionalProperties);
+        builder.append("\n}");
+        return builder.toString();
+    }
+
+}

--- a/src/test/resources/testdata/rest/options/category-options.txt
+++ b/src/test/resources/testdata/rest/options/category-options.txt
@@ -1,0 +1,208 @@
+{
+    "data": [
+        {
+            "value": 2008398,
+            "label": "Allscripts"
+        },
+        {
+            "value": 2008399,
+            "label": "Analyst123"
+        },
+        {
+            "value": 2008400,
+            "label": "API"
+        },
+        {
+            "value": 2008401,
+            "label": "Application Developer"
+        },
+        {
+            "value": 2008402,
+            "label": "ASP"
+        },
+        {
+            "value": 2008403,
+            "label": "Business Analyst"
+        },
+        {
+            "value": 2008404,
+            "label": "Business Intelligence"
+        },
+        {
+            "value": 2008405,
+            "label": "Cerner"
+        },
+        {
+            "value": 2008406,
+            "label": "Clinical Healthcare"
+        },
+        {
+            "value": 2008407,
+            "label": "Cloverleaf"
+        },
+        {
+            "value": 2008408,
+            "label": "Customer Service"
+        },
+        {
+            "value": 2008409,
+            "label": "DBA"
+        },
+        {
+            "value": 2008410,
+            "label": "Desktop Support"
+        },
+        {
+            "value": 2008411,
+            "label": "Developer"
+        },
+        {
+            "value": 2008412,
+            "label": "Eclipsys"
+        },
+        {
+            "value": 2008413,
+            "label": "Epic"
+        },
+        {
+            "value": 2008414,
+            "label": "feb3"
+        },
+        {
+            "value": 2008415,
+            "label": "GE/IDX"
+        },
+        {
+            "value": 2008416,
+            "label": "Helpdesk/Desktop Support"
+        },
+        {
+            "value": 2008417,
+            "label": "InterSystems"
+        },
+        {
+            "value": 2008418,
+            "label": "Java developer"
+        },
+        {
+            "value": 2008419,
+            "label": "Kronos"
+        },
+        {
+            "value": 2008420,
+            "label": "Lawson"
+        },
+        {
+            "value": 2008421,
+            "label": "Lorem Ipsum"
+        },
+        {
+            "value": 2008422,
+            "label": "Management"
+        },
+        {
+            "value": 2008423,
+            "label": "Management Consulting incl interim"
+        },
+        {
+            "value": 2008424,
+            "label": "McKesson"
+        },
+        {
+            "value": 2008425,
+            "label": "Meditech"
+        },
+        {
+            "value": 2008426,
+            "label": "Network Administrator"
+        },
+        {
+            "value": 2008427,
+            "label": "Network engineer"
+        },
+        {
+            "value": 2008428,
+            "label": "Network Services"
+        },
+        {
+            "value": 2008429,
+            "label": "NextGen"
+        },
+        {
+            "value": 2008430,
+            "label": "Orion"
+        },
+        {
+            "value": 2008431,
+            "label": "Other Area(s)"
+        },
+        {
+            "value": 2008432,
+            "label": "Patient Care Device Integration"
+        },
+        {
+            "value": 2008433,
+            "label": "PeopleSoft"
+        },
+        {
+            "value": 2008434,
+            "label": "Picis"
+        },
+        {
+            "value": 2008435,
+            "label": "Programming/Development"
+        },
+        {
+            "value": 2008436,
+            "label": "Project Management"
+        },
+        {
+            "value": 2008437,
+            "label": "Project Manager"
+        },
+        {
+            "value": 2008438,
+            "label": "Quality Analyst"
+        },
+        {
+            "value": 2008439,
+            "label": "Rev Cycle Management"
+        },
+        {
+            "value": 2008440,
+            "label": "SAP"
+        },
+        {
+            "value": 2008441,
+            "label": "SeeBeyond eGate ICAN JCAPS"
+        },
+        {
+            "value": 2008442,
+            "label": "Siemens"
+        },
+        {
+            "value": 2008443,
+            "label": "Support"
+        },
+        {
+            "value": 2008444,
+            "label": "Test"
+        },
+        {
+            "value": 2008445,
+            "label": "Test2"
+        },
+        {
+            "value": 2025235,
+            "label": "Test32818A"
+        },
+        {
+            "value": 2008446,
+            "label": "Test45321"
+        },
+        {
+            "value": 2008447,
+            "label": "test54321"
+        }
+    ]
+}

--- a/src/test/resources/testdata/rest/options/jobOrder-options.txt
+++ b/src/test/resources/testdata/rest/options/jobOrder-options.txt
@@ -1,0 +1,1204 @@
+{
+    "data": [
+        {
+            "value": 1437,
+            "label": "Cleaner"
+        },
+        {
+            "value": 1413,
+            "label": "Cleaners"
+        },
+        {
+            "value": 1253,
+            "label": "Clerk"
+        },
+        {
+            "value": 1489,
+            "label": "Clerk"
+        },
+        {
+            "value": 504,
+            "label": "Clerk"
+        },
+        {
+            "value": 534,
+            "label": "Client Relations Manager"
+        },
+        {
+            "value": 692,
+            "label": "Clinical Coordinator"
+        },
+        {
+            "value": 124,
+            "label": "Clinical Coordinator 124"
+        },
+        {
+            "value": 183,
+            "label": "Clinical Coordinator 183"
+        },
+        {
+            "value": 458,
+            "label": "Clinical Director -LCADC"
+        },
+        {
+            "value": 357,
+            "label": "Clinical Director of Population Health 357"
+        },
+        {
+            "value": 784,
+            "label": "Clinical Educator"
+        },
+        {
+            "value": 224,
+            "label": "Clinical Manager 224"
+        },
+        {
+            "value": 783,
+            "label": "Clinical Nurse Supervisor"
+        },
+        {
+            "value": 480,
+            "label": "Clinical Social Worker/Treatment Foster Care 480"
+        },
+        {
+            "value": 1738,
+            "label": "Clinical Supervisor"
+        },
+        {
+            "value": 99,
+            "label": "Clinical Supervisor  LICSW (DC) 99"
+        },
+        {
+            "value": 280,
+            "label": "Clinical Supervisor - Baltimore 280"
+        },
+        {
+            "value": 1858,
+            "label": "Clinical Supervisor - LCSW - LCPC"
+        },
+        {
+            "value": 123,
+            "label": "Clinical Supervisor 123"
+        },
+        {
+            "value": 523,
+            "label": "Clinical Supervisor 523"
+        },
+        {
+            "value": 180,
+            "label": "Clinical Therapist"
+        },
+        {
+            "value": 137,
+            "label": "Clinical Therapist LICSW 137"
+        },
+        {
+            "value": 1243,
+            "label": "CMT"
+        },
+        {
+            "value": 849,
+            "label": "CMT Residential Aide"
+        },
+        {
+            "value": 1815,
+            "label": "CMT Residential Aide"
+        },
+        {
+            "value": 1807,
+            "label": "CNA"
+        },
+        {
+            "value": 615,
+            "label": "CNA"
+        },
+        {
+            "value": 299,
+            "label": "CNA #299"
+        },
+        {
+            "value": 1513,
+            "label": "CNA/TME"
+        },
+        {
+            "value": 755,
+            "label": "Coding Manager - Outpatient"
+        },
+        {
+            "value": 756,
+            "label": "Coding Supervisor"
+        },
+        {
+            "value": 1162,
+            "label": "Collections Analyst"
+        },
+        {
+            "value": 1031,
+            "label": "Collections Analyst"
+        },
+        {
+            "value": 1419,
+            "label": "Commercial Collector"
+        },
+        {
+            "value": 1801,
+            "label": "Community Support Residential Aides"
+        },
+        {
+            "value": 1696,
+            "label": "Compensation Analyst"
+        },
+        {
+            "value": 1469,
+            "label": "Computer Cleaner"
+        },
+        {
+            "value": 453,
+            "label": "Consumer Care Monitor"
+        },
+        {
+            "value": 461,
+            "label": "Contract Accounting Administrator"
+        },
+        {
+            "value": 903,
+            "label": "Contracts Administrator"
+        },
+        {
+            "value": 887,
+            "label": "Controller"
+        },
+        {
+            "value": 578,
+            "label": "Controller"
+        },
+        {
+            "value": 1236,
+            "label": "Controller"
+        },
+        {
+            "value": 1565,
+            "label": "Cook"
+        },
+        {
+            "value": 1523,
+            "label": "Cook/Dishwasher"
+        },
+        {
+            "value": 1482,
+            "label": "Corporate Service Manager"
+        },
+        {
+            "value": 493,
+            "label": "Cost Accountant"
+        },
+        {
+            "value": 781,
+            "label": "Counselor"
+        },
+        {
+            "value": 182,
+            "label": "Counselor 1/CAC-AD 182"
+        },
+        {
+            "value": 199,
+            "label": "Counselor 199"
+        },
+        {
+            "value": 1831,
+            "label": "Crane Operator"
+        },
+        {
+            "value": 1778,
+            "label": "Crew Supervisor"
+        },
+        {
+            "value": 1555,
+            "label": "CSR/Inside sales"
+        },
+        {
+            "value": 272,
+            "label": "Curriculum Specialist 272"
+        },
+        {
+            "value": 669,
+            "label": "Curriculum Specialist 669"
+        },
+        {
+            "value": 1572,
+            "label": "Customer Account Representative"
+        },
+        {
+            "value": 1803,
+            "label": "Customer Service Associate"
+        },
+        {
+            "value": 1817,
+            "label": "Customer Service Representative"
+        },
+        {
+            "value": 573,
+            "label": "Customer Service Representative"
+        },
+        {
+            "value": 1879,
+            "label": "Customer Service Representative"
+        },
+        {
+            "value": 1395,
+            "label": "Customer Service Representatives"
+        },
+        {
+            "value": 852,
+            "label": "Customer Service Represnetative"
+        },
+        {
+            "value": 1293,
+            "label": "Customer Service Specialist"
+        },
+        {
+            "value": 1650,
+            "label": "Customer Service Specialist"
+        },
+        {
+            "value": 1584,
+            "label": "Customer Service/Inside Sales"
+        },
+        {
+            "value": 1852,
+            "label": "Data Entry Clerk"
+        },
+        {
+            "value": 713,
+            "label": "Data Support Specialist"
+        },
+        {
+            "value": 282,
+            "label": "Day Program 282"
+        },
+        {
+            "value": 1814,
+            "label": "Day Program Aide"
+        },
+        {
+            "value": 1705,
+            "label": "Day Program and Residential Counselor"
+        },
+        {
+            "value": 1392,
+            "label": "Day Program Driver"
+        },
+        {
+            "value": 439,
+            "label": "Day Program Residential Aid 439"
+        },
+        {
+            "value": 21,
+            "label": "DC LCSW-C/LICSW Supervisor 21"
+        },
+        {
+            "value": 23,
+            "label": "DC LGSW"
+        },
+        {
+            "value": 24,
+            "label": "DC LGSW"
+        },
+        {
+            "value": 66,
+            "label": "DC LGSW"
+        },
+        {
+            "value": 1459,
+            "label": "Dec. 10th 10:30pm - 4am"
+        },
+        {
+            "value": 1491,
+            "label": "Dec. 10th 10:30pm - 4am"
+        },
+        {
+            "value": 1457,
+            "label": "Dec. 10th 11:30am - 7pm"
+        },
+        {
+            "value": 1456,
+            "label": "Dec. 10th 5am - 12pm"
+        },
+        {
+            "value": 1458,
+            "label": "Dec. 10th 6:30pm - 2am"
+        },
+        {
+            "value": 1439,
+            "label": "Dec. 3rd 10am - 6:30pm"
+        },
+        {
+            "value": 1438,
+            "label": "Dec. 3rd 8am - 4pm"
+        },
+        {
+            "value": 1441,
+            "label": "Dec. 4th 12pm - 8:30pm"
+        },
+        {
+            "value": 1440,
+            "label": "Dec. 4th 4pm - 12:30am"
+        },
+        {
+            "value": 1443,
+            "label": "Dec. 5th 6pm - 3am"
+        },
+        {
+            "value": 1442,
+            "label": "Dec. 5th 9:30am - 6:30pm"
+        },
+        {
+            "value": 1445,
+            "label": "Dec. 6th 12:30pm - 9pm"
+        },
+        {
+            "value": 1444,
+            "label": "Dec. 6th 5am - 1pm"
+        },
+        {
+            "value": 1446,
+            "label": "Dec. 6th 8:30pm - 4:00am"
+        },
+        {
+            "value": 1448,
+            "label": "Dec. 7th 11:30am - 8pm"
+        },
+        {
+            "value": 1447,
+            "label": "Dec. 7th 5am - 12pm"
+        },
+        {
+            "value": 1449,
+            "label": "Dec. 7th 7:30pm - 3am"
+        },
+        {
+            "value": 1451,
+            "label": "Dec. 8th 11:30am - 8pm"
+        },
+        {
+            "value": 1450,
+            "label": "Dec. 8th 5am - 12pm"
+        },
+        {
+            "value": 1452,
+            "label": "Dec. 8th 7:30pm - 3am"
+        },
+        {
+            "value": 1454,
+            "label": "Dec. 9th 11:30am - 8pm"
+        },
+        {
+            "value": 1453,
+            "label": "Dec. 9th 5am - 12pm"
+        },
+        {
+            "value": 1455,
+            "label": "Dec. 9th 7:30pm - 3am"
+        },
+        {
+            "value": 218,
+            "label": "Diagnostic & Assessment Clinician 218"
+        },
+        {
+            "value": 800,
+            "label": "Diagnostic and Prescriptive Specialist"
+        },
+        {
+            "value": 162,
+            "label": "Diagnostic Assessment Clinician 162"
+        },
+        {
+            "value": 246,
+            "label": "Diagnostic Assessment Clinician 246"
+        },
+        {
+            "value": 251,
+            "label": "Direct Support Professional"
+        },
+        {
+            "value": 795,
+            "label": "Direct Support Professional"
+        },
+        {
+            "value": 754,
+            "label": "Direct Support Professional"
+        },
+        {
+            "value": 36,
+            "label": "Direct Support Professional  36"
+        },
+        {
+            "value": 1519,
+            "label": "Direct support Staff - Day program"
+        },
+        {
+            "value": 1784,
+            "label": "Direct support Staff/ Residential"
+        },
+        {
+            "value": 1201,
+            "label": "Direct support Staff/ Residential"
+        },
+        {
+            "value": 311,
+            "label": "Direct support Staff/ Residential 311"
+        },
+        {
+            "value": 367,
+            "label": "Director of Accounting and HR"
+        },
+        {
+            "value": 389,
+            "label": "Director of Behavioral Health Services"
+        },
+        {
+            "value": 264,
+            "label": "Director of Clinical Services 264"
+        },
+        {
+            "value": 297,
+            "label": "Director of Day Program 297"
+        },
+        {
+            "value": 553,
+            "label": "Director of Employment & Community Services 553"
+        },
+        {
+            "value": 34,
+            "label": "Director of Nursing"
+        },
+        {
+            "value": 361,
+            "label": "Director of Recruiting"
+        },
+        {
+            "value": 491,
+            "label": "Director of Social Work"
+        },
+        {
+            "value": 700,
+            "label": "Director of Social Work #700"
+        },
+        {
+            "value": 535,
+            "label": "Disabilities Coordinator 535"
+        },
+        {
+            "value": 1652,
+            "label": "Dispatcher"
+        },
+        {
+            "value": 1676,
+            "label": "Driver"
+        },
+        {
+            "value": 1635,
+            "label": "Driver"
+        },
+        {
+            "value": 1637,
+            "label": "Driver"
+        },
+        {
+            "value": 1337,
+            "label": "Driver"
+        },
+        {
+            "value": 1355,
+            "label": "DRIVER / SALES AGENT"
+        },
+        {
+            "value": 1063,
+            "label": "Driver/Laborer"
+        },
+        {
+            "value": 1524,
+            "label": "Driver/Warehouse"
+        },
+        {
+            "value": 1033,
+            "label": "DSP"
+        },
+        {
+            "value": 1164,
+            "label": "Dsp"
+        },
+        {
+            "value": 1394,
+            "label": "Dsp"
+        },
+        {
+            "value": 1914,
+            "label": "DSP"
+        },
+        {
+            "value": 1913,
+            "label": "DSP Day Program"
+        },
+        {
+            "value": 463,
+            "label": "Early childhood teacher 463"
+        },
+        {
+            "value": 455,
+            "label": "Education Specialist"
+        },
+        {
+            "value": 782,
+            "label": "Education Specialist"
+        },
+        {
+            "value": 177,
+            "label": "Education Specialist"
+        },
+        {
+            "value": 1826,
+            "label": "ELA Teacher"
+        },
+        {
+            "value": 1728,
+            "label": "Employee Benefits Auditor"
+        },
+        {
+            "value": 267,
+            "label": "Employment Specialist 267"
+        },
+        {
+            "value": 532,
+            "label": "Employment Specialist 532"
+        },
+        {
+            "value": 1334,
+            "label": "Engineering - Maintenance"
+        },
+        {
+            "value": 1604,
+            "label": "Enrollment Specialist"
+        },
+        {
+            "value": 1699,
+            "label": "Enrollment Specialist"
+        },
+        {
+            "value": 1212,
+            "label": "Equipment Operator"
+        },
+        {
+            "value": 665,
+            "label": "Estimator"
+        },
+        {
+            "value": 1308,
+            "label": "Event Setup - 11/08 4:30pm - 12:00am Pay: $10 "
+        },
+        {
+            "value": 1721,
+            "label": "Excursion Agent"
+        },
+        {
+            "value": 1845,
+            "label": "Executive Assistant"
+        },
+        {
+            "value": 1329,
+            "label": "Facilities Technician"
+        },
+        {
+            "value": 432,
+            "label": "Facilities Technician 432"
+        },
+        {
+            "value": 1809,
+            "label": "Facility Coordinator"
+        },
+        {
+            "value": 1859,
+            "label": "Family Centered Specialist"
+        },
+        {
+            "value": 1686,
+            "label": "Family Services Coordinator"
+        },
+        {
+            "value": 864,
+            "label": "Family Services Coordinator"
+        },
+        {
+            "value": 273,
+            "label": "Family Services Coordinator 273"
+        },
+        {
+            "value": 670,
+            "label": "Family Services Coordinator 670"
+        },
+        {
+            "value": 35,
+            "label": "Family Support Assistant - 35"
+        },
+        {
+            "value": 1872,
+            "label": "Field Technician"
+        },
+        {
+            "value": 886,
+            "label": "File Clerk"
+        },
+        {
+            "value": 892,
+            "label": "File Clerk"
+        },
+        {
+            "value": 893,
+            "label": "File Clerk"
+        },
+        {
+            "value": 894,
+            "label": "File Clerk"
+        },
+        {
+            "value": 895,
+            "label": "File Clerk"
+        },
+        {
+            "value": 896,
+            "label": "File Clerk"
+        },
+        {
+            "value": 476,
+            "label": "Financial Accounting Supervisor"
+        },
+        {
+            "value": 470,
+            "label": "Financial Assistant"
+        },
+        {
+            "value": 386,
+            "label": "Financial Assistant"
+        },
+        {
+            "value": 441,
+            "label": "Financial Associate"
+        },
+        {
+            "value": 442,
+            "label": "Financial Associate"
+        },
+        {
+            "value": 444,
+            "label": "Financial Associate"
+        },
+        {
+            "value": 446,
+            "label": "Financial Associate"
+        },
+        {
+            "value": 1797,
+            "label": "Financial Auditor"
+        },
+        {
+            "value": 1541,
+            "label": "Fleet Manager"
+        },
+        {
+            "value": 1622,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1791,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1724,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1855,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1288,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1339,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1340,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1239,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1124,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1048,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 902,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 932,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 883,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 753,
+            "label": "Floor Technician"
+        },
+        {
+            "value": 1270,
+            "label": "Fluid Technician"
+        },
+        {
+            "value": 1687,
+            "label": "Fluid Technician"
+        },
+        {
+            "value": 1514,
+            "label": "Forkilft Operator"
+        },
+        {
+            "value": 1848,
+            "label": "Forklift Operator"
+        },
+        {
+            "value": 1854,
+            "label": "ForkLift Operator"
+        },
+        {
+            "value": 1761,
+            "label": "Forklift Operator"
+        },
+        {
+            "value": 1794,
+            "label": "Forklift Operator"
+        },
+        {
+            "value": 266,
+            "label": "Foster Care Case Worker"
+        },
+        {
+            "value": 217,
+            "label": "Foster Care SW for School 217"
+        },
+        {
+            "value": 683,
+            "label": "Foster Case Worker"
+        },
+        {
+            "value": 1763,
+            "label": "Front End Loader"
+        },
+        {
+            "value": 1688,
+            "label": "Front End Loader"
+        },
+        {
+            "value": 1269,
+            "label": "Front End Loader"
+        },
+        {
+            "value": 859,
+            "label": "Fuel Tank Drainer"
+        },
+        {
+            "value": 1785,
+            "label": "Full Charge Bookkeeper"
+        },
+        {
+            "value": 149,
+            "label": "Functional Family Therapist (LGSW/LGPC) 149"
+        },
+        {
+            "value": 161,
+            "label": "Functional Family Therapy Supervisor LICSW/LPC 161"
+        },
+        {
+            "value": 1828,
+            "label": "General Labor"
+        },
+        {
+            "value": 1226,
+            "label": "General Labor"
+        },
+        {
+            "value": 1350,
+            "label": "General Labor"
+        },
+        {
+            "value": 1821,
+            "label": "General Laborers"
+        },
+        {
+            "value": 1823,
+            "label": "General Laborers"
+        },
+        {
+            "value": 927,
+            "label": "General Laborers"
+        },
+        {
+            "value": 790,
+            "label": "General Laborers"
+        },
+        {
+            "value": 1406,
+            "label": "General Laborers - Cleaning"
+        },
+        {
+            "value": 1833,
+            "label": "General Laborers 3/2/18"
+        },
+        {
+            "value": 1834,
+            "label": "General Laborers 3/4/18"
+        },
+        {
+            "value": 1835,
+            "label": "General Laborers 3/5/18"
+        },
+        {
+            "value": 1836,
+            "label": "General Laborers 3/6/18"
+        },
+        {
+            "value": 1837,
+            "label": "General Laborers 3/7/18"
+        },
+        {
+            "value": 1838,
+            "label": "General Laborers 3/8/18"
+        },
+        {
+            "value": 1839,
+            "label": "General Laborers 3/8/18"
+        },
+        {
+            "value": 420,
+            "label": "General Ledger Accountant"
+        },
+        {
+            "value": 9,
+            "label": "GNA"
+        },
+        {
+            "value": 14,
+            "label": "GNA"
+        },
+        {
+            "value": 15,
+            "label": "GNA-15"
+        },
+        {
+            "value": 1907,
+            "label": "Golf Cart Assemblers"
+        },
+        {
+            "value": 1908,
+            "label": "Golf Cart Assemblers"
+        },
+        {
+            "value": 1213,
+            "label": "Grading Foreman"
+        },
+        {
+            "value": 1248,
+            "label": "Granite Polisher"
+        },
+        {
+            "value": 1423,
+            "label": "Granite Warehouse Worker"
+        },
+        {
+            "value": 1112,
+            "label": "Grant Writer"
+        },
+        {
+            "value": 762,
+            "label": "Grants Manager"
+        },
+        {
+            "value": 530,
+            "label": "Grants Manager"
+        },
+        {
+            "value": 184,
+            "label": "Graphic Teacher-Special Education"
+        },
+        {
+            "value": 879,
+            "label": "Handyman"
+        },
+        {
+            "value": 1380,
+            "label": "Harvester"
+        },
+        {
+            "value": 1607,
+            "label": "Harvester"
+        },
+        {
+            "value": 1591,
+            "label": "Harvester"
+        },
+        {
+            "value": 1107,
+            "label": "Head Teacher - Head start"
+        },
+        {
+            "value": 1185,
+            "label": "High School Science Teacher"
+        },
+        {
+            "value": 416,
+            "label": "High School Science Teacher 416"
+        },
+        {
+            "value": 305,
+            "label": "Home Health LPN - Annapolis"
+        },
+        {
+            "value": 316,
+            "label": "Home Health Quality Assurance Manager - Columbia 316"
+        },
+        {
+            "value": 307,
+            "label": "Home Health RN - Annapolis 307"
+        },
+        {
+            "value": 309,
+            "label": "Home Health RN - Columbia 309"
+        },
+        {
+            "value": 322,
+            "label": "Home Health RN - Silver Spring"
+        },
+        {
+            "value": 366,
+            "label": "Home Health RN - VA Beach 366"
+        },
+        {
+            "value": 314,
+            "label": "Home Health RN Manager Of Clinical Practice - Silver Spring 314"
+        },
+        {
+            "value": 303,
+            "label": "Home Health RN Manager Of Clinical Practice- Annapolis 303"
+        },
+        {
+            "value": 325,
+            "label": "Home Health RN Towson"
+        },
+        {
+            "value": 621,
+            "label": "Home Health RN Towson"
+        },
+        {
+            "value": 1576,
+            "label": "Homeless Outreach RN/LPN"
+        },
+        {
+            "value": 501,
+            "label": "House Manager 501"
+        },
+        {
+            "value": 1601,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1697,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1698,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1656,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1651,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1830,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1847,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1856,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1818,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1804,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1789,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1781,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1792,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1722,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1723,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1123,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1238,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1274,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1097,
+            "label": "Housekeeper "
+        },
+        {
+            "value": 1361,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1342,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1330,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1332,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1325,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1432,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1421,
+            "label": "Housekeeper"
+        },
+        {
+            "value": 1311,
+            "label": "Housekeeper - 11/09 11:00am - 11:00pm / 12 hour shift  Pay: $12 "
+        },
+        {
+            "value": 1312,
+            "label": "Housekeeper - 11/09 11:00pm - 7:00am  Pay: $11.50 "
+        },
+        {
+            "value": 1315,
+            "label": "Housekeeper - 11/10 10:30pm - 6:00am  Pay: $11.50"
+        },
+        {
+            "value": 1314,
+            "label": "Housekeeper - 11/10 3:30pm - 11:30pm   Pay: $10.50"
+        },
+        {
+            "value": 1313,
+            "label": "Housekeeper - 11/10 7:30am - 3:30pm  Pay: $10.50"
+        },
+        {
+            "value": 1319,
+            "label": "Housekeeper - 11/11 11:30pm - 6:00am  Pay: $11.50"
+        },
+        {
+            "value": 1318,
+            "label": "Housekeeper - 11/11 4:00pm - 12:00am  Pay: $11"
+        },
+        {
+            "value": 1317,
+            "label": "Housekeeper - 11/11 7:30am - 4:00pm  Pay: $10.50"
+        },
+        {
+            "value": 1321,
+            "label": "Housekeeper - 11/12 7:00pm - 3:00am  Pay: $11.50"
+        },
+        {
+            "value": 1320,
+            "label": "Housekeeper - 11/12 8:00am - 8:00pm / 12 hour shift  Pay: $12"
+        },
+        {
+            "value": 1793,
+            "label": "Housekeeper/Utilities Technician"
+        },
+        {
+            "value": 1829,
+            "label": "Housekeeper/Utilities Technician"
+        },
+        {
+            "value": 1062,
+            "label": "Housekeeping"
+        },
+        {
+            "value": 1310,
+            "label": "Housekeeping - 11/09 6:00am - 11:30am  Pay: $10 "
+        },
+        {
+            "value": 1344,
+            "label": "Housekeeping Leads - 11/08/17 4:30pm - 12:00am "
+        },
+        {
+            "value": 1345,
+            "label": "Housekeeping Leads - 11/09/17 11:00am - 11:30pm"
+        },
+        {
+            "value": 1346,
+            "label": "Housekeeping Leads - 11/09/17 11:00pm - 7:00am"
+        },
+        {
+            "value": 1347,
+            "label": "Housekeeping Leads - 11/10/17 10:30pm - 6:00am"
+        },
+        {
+            "value": 1385,
+            "label": "Housekeeping Leads - 11/10/17 3:30pm - 11:00pm"
+        },
+        {
+            "value": 1348,
+            "label": "Housekeeping Leads - 11/11/17 11:30pm - 6:00am"
+        }
+    ]
+}

--- a/src/test/resources/testdata/rest/options/northAmericaState-options.txt
+++ b/src/test/resources/testdata/rest/options/northAmericaState-options.txt
@@ -1,0 +1,264 @@
+{
+    "data": [
+        {
+            "value": "AL",
+            "label": "Alabama"
+        },
+        {
+            "value": "AK",
+            "label": "Alaska"
+        },
+        {
+            "value": "AZ",
+            "label": "Arizona"
+        },
+        {
+            "value": "AR",
+            "label": "Arkansas"
+        },
+        {
+            "value": "CA",
+            "label": "California"
+        },
+        {
+            "value": "CO",
+            "label": "Colorado"
+        },
+        {
+            "value": "CT",
+            "label": "Connecticut"
+        },
+        {
+            "value": "DE",
+            "label": "Delaware"
+        },
+        {
+            "value": "DC",
+            "label": "District of Columbia"
+        },
+        {
+            "value": "FL",
+            "label": "Florida"
+        },
+        {
+            "value": "GA",
+            "label": "Georgia"
+        },
+        {
+            "value": "HI",
+            "label": "Hawaii"
+        },
+        {
+            "value": "ID",
+            "label": "Idaho"
+        },
+        {
+            "value": "IL",
+            "label": "Illinois"
+        },
+        {
+            "value": "IN",
+            "label": "Indiana"
+        },
+        {
+            "value": "IA",
+            "label": "Iowa"
+        },
+        {
+            "value": "KS",
+            "label": "Kansas"
+        },
+        {
+            "value": "KY",
+            "label": "Kentucky"
+        },
+        {
+            "value": "LA",
+            "label": "Louisiana"
+        },
+        {
+            "value": "ME",
+            "label": "Maine"
+        },
+        {
+            "value": "MD",
+            "label": "Maryland"
+        },
+        {
+            "value": "MA",
+            "label": "Massachusetts"
+        },
+        {
+            "value": "MI",
+            "label": "Michigan"
+        },
+        {
+            "value": "MN",
+            "label": "Minnesota"
+        },
+        {
+            "value": "MS",
+            "label": "Mississippi"
+        },
+        {
+            "value": "MO",
+            "label": "Missouri"
+        },
+        {
+            "value": "MT",
+            "label": "Montana"
+        },
+        {
+            "value": "NE",
+            "label": "Nebraska"
+        },
+        {
+            "value": "NV",
+            "label": "Nevada"
+        },
+        {
+            "value": "NH",
+            "label": "New Hampshire"
+        },
+        {
+            "value": "NJ",
+            "label": "New Jersey"
+        },
+        {
+            "value": "NM",
+            "label": "New Mexico"
+        },
+        {
+            "value": "NY",
+            "label": "New York"
+        },
+        {
+            "value": "NC",
+            "label": "North Carolina"
+        },
+        {
+            "value": "ND",
+            "label": "North Dakota"
+        },
+        {
+            "value": "OH",
+            "label": "Ohio"
+        },
+        {
+            "value": "OK",
+            "label": "Oklahoma"
+        },
+        {
+            "value": "OR",
+            "label": "Oregon"
+        },
+        {
+            "value": "PA",
+            "label": "Pennsylvania"
+        },
+        {
+            "value": "RI",
+            "label": "Rhode Island"
+        },
+        {
+            "value": "SC",
+            "label": "South Carolina"
+        },
+        {
+            "value": "SD",
+            "label": "South Dakota"
+        },
+        {
+            "value": "TN",
+            "label": "Tennessee"
+        },
+        {
+            "value": "TX",
+            "label": "Texas"
+        },
+        {
+            "value": "UT",
+            "label": "Utah"
+        },
+        {
+            "value": "VT",
+            "label": "Vermont"
+        },
+        {
+            "value": "VA",
+            "label": "Virginia"
+        },
+        {
+            "value": "WA",
+            "label": "Washington"
+        },
+        {
+            "value": "WV",
+            "label": "West Virginia"
+        },
+        {
+            "value": "WI",
+            "label": "Wisconsin"
+        },
+        {
+            "value": "WY",
+            "label": "Wyoming"
+        },
+        {
+            "value": "AB",
+            "label": "Alberta"
+        },
+        {
+            "value": "BC",
+            "label": "British Columbia"
+        },
+        {
+            "value": "MB",
+            "label": "Manitoba"
+        },
+        {
+            "value": "NB",
+            "label": "New Brunswick"
+        },
+        {
+            "value": "NF",
+            "label": "New Foundland (NF)"
+        },
+        {
+            "value": "NL",
+            "label": "New Foundland (NL)"
+        },
+        {
+            "value": "NT",
+            "label": "Northwest Territories"
+        },
+        {
+            "value": "NS",
+            "label": "Nova Scotia"
+        },
+        {
+            "value": "NU",
+            "label": "Nunavut"
+        },
+        {
+            "value": "ON",
+            "label": "Ontario"
+        },
+        {
+            "value": "PE",
+            "label": "Prince Edward Island"
+        },
+        {
+            "value": "QC",
+            "label": "Quebec"
+        },
+        {
+            "value": "SK",
+            "label": "Saskatchewan"
+        },
+        {
+            "value": "YT",
+            "label": "Yukon"
+        }
+    ]
+}

--- a/src/test/resources/testdata/rest/options/person-options.txt
+++ b/src/test/resources/testdata/rest/options/person-options.txt
@@ -1,0 +1,1204 @@
+{
+    "data": [
+        {
+            "value": 34879,
+            "label": "\"Ms. Smith"
+        },
+        {
+            "value": 35131,
+            "label": "\"Not the  Receptionist\""
+        },
+        {
+            "value": 32623,
+            "label": "(443) 473-8676 (443) 473-8676"
+        },
+        {
+            "value": 22938,
+            "label": "-Ross and Sandra Flax"
+        },
+        {
+            "value": 32351,
+            "label": "A Hall"
+        },
+        {
+            "value": 17791,
+            "label": "A Tietze "
+        },
+        {
+            "value": 25965,
+            "label": "A'Ishah Young"
+        },
+        {
+            "value": 26140,
+            "label": "A'shontay Rogers"
+        },
+        {
+            "value": 41344,
+            "label": "A.J.  Fenske"
+        },
+        {
+            "value": 37868,
+            "label": "Aalilyah Williams"
+        },
+        {
+            "value": 21512,
+            "label": "Aaliyah Marshman"
+        },
+        {
+            "value": 39990,
+            "label": "Aaliyah Wallace"
+        },
+        {
+            "value": 26853,
+            "label": "Aarika Wood"
+        },
+        {
+            "value": 5440,
+            "label": "Aaris Adams"
+        },
+        {
+            "value": 33341,
+            "label": "Aaron  Briggs"
+        },
+        {
+            "value": 42827,
+            "label": "Aaron  Potutschnig"
+        },
+        {
+            "value": 34609,
+            "label": "Aaron  Smith"
+        },
+        {
+            "value": 27117,
+            "label": "Aaron Aikens"
+        },
+        {
+            "value": 9841,
+            "label": "Aaron Ament"
+        },
+        {
+            "value": 19165,
+            "label": "AARON BOOSE"
+        },
+        {
+            "value": 9921,
+            "label": "Aaron Bourne"
+        },
+        {
+            "value": 39262,
+            "label": "Aaron Brodie"
+        },
+        {
+            "value": 13065,
+            "label": "Aaron Burgess"
+        },
+        {
+            "value": 42056,
+            "label": "Aaron Calhoun"
+        },
+        {
+            "value": 17813,
+            "label": "Aaron Campbell"
+        },
+        {
+            "value": 42296,
+            "label": "AARON CARR"
+        },
+        {
+            "value": 31417,
+            "label": "Aaron Collins"
+        },
+        {
+            "value": 29912,
+            "label": "Aaron Cudjoe"
+        },
+        {
+            "value": 33487,
+            "label": "AARON EDMONDSON"
+        },
+        {
+            "value": 35915,
+            "label": "Aaron Faulkner"
+        },
+        {
+            "value": 38378,
+            "label": "Aaron frazier"
+        },
+        {
+            "value": 40850,
+            "label": "Aaron Gold"
+        },
+        {
+            "value": 30846,
+            "label": "Aaron Harris"
+        },
+        {
+            "value": 38219,
+            "label": "Aaron Hawkes"
+        },
+        {
+            "value": 23342,
+            "label": "Aaron k"
+        },
+        {
+            "value": 14159,
+            "label": "Aaron Keeney"
+        },
+        {
+            "value": 39119,
+            "label": "Aaron Kramer"
+        },
+        {
+            "value": 36143,
+            "label": "Aaron Kuhn"
+        },
+        {
+            "value": 36146,
+            "label": "Aaron Kuhn"
+        },
+        {
+            "value": 38749,
+            "label": "Aaron Lawson"
+        },
+        {
+            "value": 40399,
+            "label": "Aaron McDowell"
+        },
+        {
+            "value": 41062,
+            "label": "Aaron McLaughlin"
+        },
+        {
+            "value": 30680,
+            "label": "Aaron Miller"
+        },
+        {
+            "value": 37129,
+            "label": "Aaron Muse"
+        },
+        {
+            "value": 20726,
+            "label": "Aaron Nolastname"
+        },
+        {
+            "value": 25796,
+            "label": "Aaron Richardson"
+        },
+        {
+            "value": 24807,
+            "label": "Aaron Roesch"
+        },
+        {
+            "value": 24622,
+            "label": "Aaron Smith"
+        },
+        {
+            "value": 29515,
+            "label": "Aaron  Sopko"
+        },
+        {
+            "value": 14865,
+            "label": "Aaron Steiner"
+        },
+        {
+            "value": 34844,
+            "label": "Aaron Stevenson"
+        },
+        {
+            "value": 33929,
+            "label": "Aaron Thompson"
+        },
+        {
+            "value": 35916,
+            "label": "Aaron Tyson"
+        },
+        {
+            "value": 35715,
+            "label": "Aaron Ubunama"
+        },
+        {
+            "value": 31989,
+            "label": "Aaron Vandermeer"
+        },
+        {
+            "value": 16577,
+            "label": "Aaron White"
+        },
+        {
+            "value": 40022,
+            "label": "Aaron Willingham"
+        },
+        {
+            "value": 6665,
+            "label": "Aaron Milton, Jr."
+        },
+        {
+            "value": 8958,
+            "label": "Aaronei Humphrey"
+        },
+        {
+            "value": 26111,
+            "label": "Aarron Langley"
+        },
+        {
+            "value": 35405,
+            "label": "Aaryn rust"
+        },
+        {
+            "value": 14558,
+            "label": "Aazim Lawson"
+        },
+        {
+            "value": 36950,
+            "label": "Abass Turay"
+        },
+        {
+            "value": 5447,
+            "label": "Abayomi Adebowale"
+        },
+        {
+            "value": 39227,
+            "label": "aBBACUS 30%"
+        },
+        {
+            "value": 30205,
+            "label": "Abbey A"
+        },
+        {
+            "value": 13849,
+            "label": "Abbey Keppel"
+        },
+        {
+            "value": 25359,
+            "label": "Abbey Krysiak"
+        },
+        {
+            "value": 32920,
+            "label": "Abbie Cornblatt"
+        },
+        {
+            "value": 32535,
+            "label": "Abbie n/a"
+        },
+        {
+            "value": 35299,
+            "label": "Abbie n/a"
+        },
+        {
+            "value": 30525,
+            "label": "Abby Bass"
+        },
+        {
+            "value": 40011,
+            "label": "Abby BCH"
+        },
+        {
+            "value": 43008,
+            "label": "Abby Persky"
+        },
+        {
+            "value": 38747,
+            "label": "Abby Zimmerman"
+        },
+        {
+            "value": 25863,
+            "label": "Abdel Vega"
+        },
+        {
+            "value": 29086,
+            "label": "Abdul Arasah"
+        },
+        {
+            "value": 17522,
+            "label": "Abdul Kingdo"
+        },
+        {
+            "value": 38005,
+            "label": "ABDUL  SALAAM"
+        },
+        {
+            "value": 26659,
+            "label": "Abdul Thollie"
+        },
+        {
+            "value": 14611,
+            "label": "Abdul Aziz Kamara"
+        },
+        {
+            "value": 35208,
+            "label": "Abdulai Sankoh"
+        },
+        {
+            "value": 9518,
+            "label": "abdulai sesay"
+        },
+        {
+            "value": 41054,
+            "label": "Abdulwaheed Alaya"
+        },
+        {
+            "value": 42379,
+            "label": "Abebe Ephrem"
+        },
+        {
+            "value": 38238,
+            "label": "Abel Mussazgi"
+        },
+        {
+            "value": 42740,
+            "label": "Abel Uwanogho"
+        },
+        {
+            "value": 23086,
+            "label": "ABELARDO  ABREU PALMERO"
+        },
+        {
+            "value": 5456,
+            "label": "Abena Adoko"
+        },
+        {
+            "value": 17863,
+            "label": "ABGIRL GAPARE"
+        },
+        {
+            "value": 9287,
+            "label": "Abhik Nath"
+        },
+        {
+            "value": 9288,
+            "label": "Abhik Nath"
+        },
+        {
+            "value": 20737,
+            "label": "Abhik Saha"
+        },
+        {
+            "value": 26353,
+            "label": "Abigael Foster"
+        },
+        {
+            "value": 37944,
+            "label": "Abigail Camja"
+        },
+        {
+            "value": 29663,
+            "label": "Abigail Elgie"
+        },
+        {
+            "value": 38319,
+            "label": "Abigail Garcia"
+        },
+        {
+            "value": 14013,
+            "label": "Abigail Lowe"
+        },
+        {
+            "value": 10578,
+            "label": "Abigail Smith"
+        },
+        {
+            "value": 17414,
+            "label": "Abigail Tussing"
+        },
+        {
+            "value": 7379,
+            "label": "Abigail Williams"
+        },
+        {
+            "value": 13980,
+            "label": "Abike Mohammed"
+        },
+        {
+            "value": 16101,
+            "label": "Abimbola Ajala"
+        },
+        {
+            "value": 30044,
+            "label": "Abiodun Anjorin"
+        },
+        {
+            "value": 40786,
+            "label": "Abiola Oladimeji"
+        },
+        {
+            "value": 16037,
+            "label": "Abisogun Macauley"
+        },
+        {
+            "value": 5475,
+            "label": "Abisola Alade"
+        },
+        {
+            "value": 29025,
+            "label": "Abisola Shoniregun"
+        },
+        {
+            "value": 9269,
+            "label": "Abosede Musafawu"
+        },
+        {
+            "value": 9270,
+            "label": "Abosede Musafawu"
+        },
+        {
+            "value": 16099,
+            "label": "Abosede Rufai"
+        },
+        {
+            "value": 9581,
+            "label": "Abosede Sobo"
+        },
+        {
+            "value": 16732,
+            "label": "Abraham Esquivel"
+        },
+        {
+            "value": 13133,
+            "label": "Abraham Girmay"
+        },
+        {
+            "value": 34843,
+            "label": "Abraham Tucker"
+        },
+        {
+            "value": 34881,
+            "label": "Abrea Allen"
+        },
+        {
+            "value": 39165,
+            "label": "Abril Thomas"
+        },
+        {
+            "value": 42093,
+            "label": "Abrilya Catlin"
+        },
+        {
+            "value": 37965,
+            "label": "Abrionna Thomas"
+        },
+        {
+            "value": 41106,
+            "label": "Abu Fofana"
+        },
+        {
+            "value": 7875,
+            "label": "Abubakarr Jr King"
+        },
+        {
+            "value": 27181,
+            "label": "Acey Patterson"
+        },
+        {
+            "value": 40966,
+            "label": "Achaunty Sessions"
+        },
+        {
+            "value": 36808,
+            "label": "Achike Oranye"
+        },
+        {
+            "value": 13694,
+            "label": "Ackson Mwimbi"
+        },
+        {
+            "value": 39521,
+            "label": "Acqualine Pridget"
+        },
+        {
+            "value": 36525,
+            "label": "Action n"
+        },
+        {
+            "value": 9962,
+            "label": "Ada Campbell"
+        },
+        {
+            "value": 15101,
+            "label": "Ada Chambliss"
+        },
+        {
+            "value": 22231,
+            "label": "ADA  LINARES"
+        },
+        {
+            "value": 42169,
+            "label": "Ada Ojeda"
+        },
+        {
+            "value": 26918,
+            "label": "Ada Sell"
+        },
+        {
+            "value": 14413,
+            "label": "Ada Simmons"
+        },
+        {
+            "value": 25805,
+            "label": "Adaeze Uzoukwu"
+        },
+        {
+            "value": 24370,
+            "label": "adai h"
+        },
+        {
+            "value": 32358,
+            "label": "Adalaine Wilson"
+        },
+        {
+            "value": 27396,
+            "label": "Adalberto Valcarcel"
+        },
+        {
+            "value": 37212,
+            "label": "Adam  Hunt"
+        },
+        {
+            "value": 35965,
+            "label": "Adam a"
+        },
+        {
+            "value": 37334,
+            "label": "Adam Collins"
+        },
+        {
+            "value": 42871,
+            "label": "Adam Covell"
+        },
+        {
+            "value": 34257,
+            "label": "Adam Farris"
+        },
+        {
+            "value": 34795,
+            "label": "Adam  Fauer"
+        },
+        {
+            "value": 29615,
+            "label": "Adam Follmer"
+        },
+        {
+            "value": 5984,
+            "label": "adam fongyen"
+        },
+        {
+            "value": 37489,
+            "label": "Adam Frederick"
+        },
+        {
+            "value": 13435,
+            "label": "Adam  Gomez "
+        },
+        {
+            "value": 36192,
+            "label": "Adam Green"
+        },
+        {
+            "value": 32779,
+            "label": "Adam Hauf"
+        },
+        {
+            "value": 27242,
+            "label": "Adam Hicks"
+        },
+        {
+            "value": 38659,
+            "label": "Adam Hopkins"
+        },
+        {
+            "value": 31150,
+            "label": "Adam Jamison"
+        },
+        {
+            "value": 29338,
+            "label": "ADAM JANKIEWICZ"
+        },
+        {
+            "value": 41241,
+            "label": "Adam Kopp"
+        },
+        {
+            "value": 42570,
+            "label": "Adam Lavenson"
+        },
+        {
+            "value": 39545,
+            "label": "Adam Marcum"
+        },
+        {
+            "value": 28522,
+            "label": "Adam Mills"
+        },
+        {
+            "value": 21713,
+            "label": "Adam Myers"
+        },
+        {
+            "value": 19067,
+            "label": "Adam Nolastname"
+        },
+        {
+            "value": 22189,
+            "label": "Adam Sielicki"
+        },
+        {
+            "value": 22147,
+            "label": "Adam Villard"
+        },
+        {
+            "value": 20464,
+            "label": "Adam Wells"
+        },
+        {
+            "value": 31148,
+            "label": "Adam White"
+        },
+        {
+            "value": 28606,
+            "label": "Adam Woodford"
+        },
+        {
+            "value": 36004,
+            "label": "Adam Zayed"
+        },
+        {
+            "value": 35720,
+            "label": "Adama Kamara"
+        },
+        {
+            "value": 9072,
+            "label": "Adama Kargbo"
+        },
+        {
+            "value": 14221,
+            "label": "Adama Panda"
+        },
+        {
+            "value": 22284,
+            "label": "ADANAKAI WHEELER"
+        },
+        {
+            "value": 26053,
+            "label": "Adassa Grant"
+        },
+        {
+            "value": 7725,
+            "label": "ADDIE GIFFIN"
+        },
+        {
+            "value": 7757,
+            "label": "Addie Griffin"
+        },
+        {
+            "value": 24418,
+            "label": "Ade obadare"
+        },
+        {
+            "value": 32565,
+            "label": "Ade Ojomo"
+        },
+        {
+            "value": 30039,
+            "label": "Adebanke Ogunwumi"
+        },
+        {
+            "value": 41792,
+            "label": "Adebayo Adediran"
+        },
+        {
+            "value": 14825,
+            "label": "Adebimpe Osho"
+        },
+        {
+            "value": 8118,
+            "label": "adebimpe salako"
+        },
+        {
+            "value": 8349,
+            "label": "Adebisi Ajetunmobi"
+        },
+        {
+            "value": 42370,
+            "label": "ADEBOLA MANUWA"
+        },
+        {
+            "value": 9349,
+            "label": "Adebola Oludaisi"
+        },
+        {
+            "value": 14128,
+            "label": "Adebowale Ehinola"
+        },
+        {
+            "value": 15151,
+            "label": "Adebukola Adelugba"
+        },
+        {
+            "value": 8966,
+            "label": "Adebukola Ibukun"
+        },
+        {
+            "value": 9098,
+            "label": "Adedapo Laditan"
+        },
+        {
+            "value": 8329,
+            "label": "Adedayo Adekoga"
+        },
+        {
+            "value": 9017,
+            "label": "Adefisayo Johnson"
+        },
+        {
+            "value": 14428,
+            "label": "Adekunle Olegere"
+        },
+        {
+            "value": 40968,
+            "label": "ADEL LANIER"
+        },
+        {
+            "value": 42321,
+            "label": "Adela Acevedo"
+        },
+        {
+            "value": 22069,
+            "label": "ADELIA  FERNANDEZ"
+        },
+        {
+            "value": 19346,
+            "label": "ADELINE FORYOUNG"
+        },
+        {
+            "value": 14959,
+            "label": "Adeline Mangwa"
+        },
+        {
+            "value": 6636,
+            "label": "Adeline McTavous"
+        },
+        {
+            "value": 23855,
+            "label": "Adeline Tenghu"
+        },
+        {
+            "value": 34535,
+            "label": "Adell Lee"
+        },
+        {
+            "value": 7493,
+            "label": "ADEMOLA APATA"
+        },
+        {
+            "value": 9815,
+            "label": "Adenike Adelugba"
+        },
+        {
+            "value": 17215,
+            "label": "Adenike Dobson"
+        },
+        {
+            "value": 28707,
+            "label": "ADENIKE ODUBORE"
+        },
+        {
+            "value": 6800,
+            "label": "Adenike Okoduwa"
+        },
+        {
+            "value": 13460,
+            "label": "Adenike Omotosho"
+        },
+        {
+            "value": 13120,
+            "label": "Adeniyi Ajayi"
+        },
+        {
+            "value": 10299,
+            "label": "Adeola Kolajo"
+        },
+        {
+            "value": 31044,
+            "label": "Adeola Olotu"
+        },
+        {
+            "value": 8602,
+            "label": "Aderiyike Cherenfant"
+        },
+        {
+            "value": 8332,
+            "label": "Adeseye Adepoju"
+        },
+        {
+            "value": 8353,
+            "label": "Adesola Akindele"
+        },
+        {
+            "value": 15094,
+            "label": "Adesuyi Arojojoye"
+        },
+        {
+            "value": 35844,
+            "label": "ADETOLA SHABI"
+        },
+        {
+            "value": 31456,
+            "label": "ADETUTU ADEPARIOYE"
+        },
+        {
+            "value": 8663,
+            "label": "Adeyinka Da-costa"
+        },
+        {
+            "value": 8020,
+            "label": "Adeyinka Onifade"
+        },
+        {
+            "value": 8252,
+            "label": "Adhikari Toni Vlasits"
+        },
+        {
+            "value": 19335,
+            "label": "ADI ADAIR"
+        },
+        {
+            "value": 10014,
+            "label": "Adia Crawford"
+        },
+        {
+            "value": 6532,
+            "label": "Adina Madden"
+        },
+        {
+            "value": 32336,
+            "label": "Adine  Cumberland"
+        },
+        {
+            "value": 27489,
+            "label": "Aditi Chopra"
+        },
+        {
+            "value": 28425,
+            "label": "Admin  A"
+        },
+        {
+            "value": 32431,
+            "label": "Admin Admin"
+        },
+        {
+            "value": 33818,
+            "label": "Admin Admin"
+        },
+        {
+            "value": 27207,
+            "label": "Admin ll"
+        },
+        {
+            "value": 26689,
+            "label": "Admin Mailbox"
+        },
+        {
+            "value": 36319,
+            "label": "Admin Mailbox"
+        },
+        {
+            "value": 37415,
+            "label": "Admin n/a"
+        },
+        {
+            "value": 27255,
+            "label": "Admin NA"
+        },
+        {
+            "value": 25434,
+            "label": "Admin NA"
+        },
+        {
+            "value": 25737,
+            "label": "Admin NA"
+        },
+        {
+            "value": 28330,
+            "label": "admin na"
+        },
+        {
+            "value": 33643,
+            "label": "Admin na"
+        },
+        {
+            "value": 34454,
+            "label": "Admin NA"
+        },
+        {
+            "value": 32904,
+            "label": "Admin NA"
+        },
+        {
+            "value": 12285,
+            "label": "Admin Oasis the Center for Mental Health,"
+        },
+        {
+            "value": 36237,
+            "label": "Admin S"
+        },
+        {
+            "value": 31253,
+            "label": "Admin. na"
+        },
+        {
+            "value": 34267,
+            "label": "Admin. VM"
+        },
+        {
+            "value": 24311,
+            "label": "Adolfo Ticlavilca"
+        },
+        {
+            "value": 7472,
+            "label": "ADOLPHUS AGBOR"
+        },
+        {
+            "value": 36729,
+            "label": "Adolphus Price"
+        },
+        {
+            "value": 18239,
+            "label": "Adon Cherry-Bey"
+        },
+        {
+            "value": 31338,
+            "label": "Adonys Gonzalez"
+        },
+        {
+            "value": 43089,
+            "label": "Adoré Escobar"
+        },
+        {
+            "value": 40710,
+            "label": "Adoshia Flythe"
+        },
+        {
+            "value": 42864,
+            "label": "Adrian Adams"
+        },
+        {
+            "value": 40401,
+            "label": "Adrian Barnes"
+        },
+        {
+            "value": 28064,
+            "label": "Adrian Baxter"
+        },
+        {
+            "value": 26562,
+            "label": "adrian bowen"
+        },
+        {
+            "value": 16601,
+            "label": "Adrian Brewington"
+        },
+        {
+            "value": 36510,
+            "label": "Adrian Cullen"
+        },
+        {
+            "value": 32079,
+            "label": "Adrian Eskridge"
+        },
+        {
+            "value": 23351,
+            "label": "Adrian h"
+        },
+        {
+            "value": 10225,
+            "label": "Adrian Humphreys"
+        },
+        {
+            "value": 40423,
+            "label": "Adrian King"
+        },
+        {
+            "value": 18271,
+            "label": "Adrian McDivitt"
+        },
+        {
+            "value": 38662,
+            "label": "ADRIAN PERKINS"
+        },
+        {
+            "value": 20402,
+            "label": "Adrian Rowe"
+        },
+        {
+            "value": 39307,
+            "label": "Adrian Sapp"
+        },
+        {
+            "value": 40006,
+            "label": "Adrian Thomas"
+        },
+        {
+            "value": 36958,
+            "label": "Adrian  Turner"
+        },
+        {
+            "value": 25704,
+            "label": "Adrian Walker"
+        },
+        {
+            "value": 33960,
+            "label": "Adrian Wharton"
+        },
+        {
+            "value": 14235,
+            "label": "Adriana Escobar"
+        },
+        {
+            "value": 22784,
+            "label": "Adriana h"
+        },
+        {
+            "value": 21060,
+            "label": "Adriana Hoffman"
+        },
+        {
+            "value": 8487,
+            "label": "Adriane Booker"
+        },
+        {
+            "value": 31310,
+            "label": "Adriane English"
+        },
+        {
+            "value": 42323,
+            "label": "Adriane Flythe"
+        },
+        {
+            "value": 13699,
+            "label": "Adriane Wiley"
+        },
+        {
+            "value": 27134,
+            "label": "ADRIANNA DELOUSTAL"
+        },
+        {
+            "value": 9267,
+            "label": "Adrianna Murphy"
+        },
+        {
+            "value": 9268,
+            "label": "Adrianna Murphy"
+        },
+        {
+            "value": 6148,
+            "label": "Adrianne Hawkes"
+        },
+        {
+            "value": 38552,
+            "label": "Adriano Carpio"
+        },
+        {
+            "value": 10400,
+            "label": "Adrieane Murray"
+        },
+        {
+            "value": 35284,
+            "label": "ADRIEN STRAUGHN"
+        },
+        {
+            "value": 36041,
+            "label": "Adrien Williams"
+        },
+        {
+            "value": 14887,
+            "label": "Adrienne Aaron"
+        },
+        {
+            "value": 35908,
+            "label": "Adrienne  Abunassar"
+        },
+        {
+            "value": 40898,
+            "label": "Adrienne Alston"
+        },
+        {
+            "value": 13417,
+            "label": "Adrienne Anne Jenkins"
+        },
+        {
+            "value": 39991,
+            "label": "Adrienne Blyther"
+        },
+        {
+            "value": 29936,
+            "label": "Adrienne Butler"
+        },
+        {
+            "value": 8693,
+            "label": "Adrienne Dezurn"
+        },
+        {
+            "value": 5921,
+            "label": "Adrienne Ellis"
+        },
+        {
+            "value": 14202,
+            "label": "Adrienne Harrington"
+        },
+        {
+            "value": 41550,
+            "label": "Adrienne Kinchen-Perry"
+        },
+        {
+            "value": 37327,
+            "label": "Adrienne Mitchell"
+        },
+        {
+            "value": 16635,
+            "label": "Adrienne Oneto"
+        },
+        {
+            "value": 18367,
+            "label": "Adrienne  Roper"
+        },
+        {
+            "value": 13153,
+            "label": "Adrienne Stephens"
+        },
+        {
+            "value": 7193,
+            "label": "Adrienne Taylor"
+        },
+        {
+            "value": 42678,
+            "label": "Adry Eusebio"
+        },
+        {
+            "value": 16182,
+            "label": "Adwoa Kessey"
+        },
+        {
+            "value": 40180,
+            "label": "Aerian Butler"
+        },
+        {
+            "value": 31107,
+            "label": "Aeron Alberti"
+        },
+        {
+            "value": 14345,
+            "label": "Afework Hailu"
+        },
+        {
+            "value": 11182,
+            "label": "Afghani Barakzai"
+        },
+        {
+            "value": 16802,
+            "label": "Afghani Barkzai"
+        },
+        {
+            "value": 35895,
+            "label": "Afia Jabin"
+        }
+    ]
+}

--- a/src/test/resources/testdata/rest/options/state-UKcountry-options.txt
+++ b/src/test/resources/testdata/rest/options/state-UKcountry-options.txt
@@ -1,0 +1,528 @@
+{
+    "data": [
+        {
+            "value": 72,
+            "label": "Aberdeenshire"
+        },
+        {
+            "value": 73,
+            "label": "Alderney"
+        },
+        {
+            "value": 75,
+            "label": "Angus"
+        },
+        {
+            "value": 3833,
+            "label": "Antrim and Newtownabbey"
+        },
+        {
+            "value": 3831,
+            "label": "Argyllshire"
+        },
+        {
+            "value": 3830,
+            "label": "Armagh"
+        },
+        {
+            "value": 3823,
+            "label": "Ayrshire"
+        },
+        {
+            "value": 82,
+            "label": "Ballymena"
+        },
+        {
+            "value": 83,
+            "label": "Ballymoney"
+        },
+        {
+            "value": 84,
+            "label": "Banbridge"
+        },
+        {
+            "value": 85,
+            "label": "Banffshire"
+        },
+        {
+            "value": 86,
+            "label": "Bedfordshire"
+        },
+        {
+            "value": 3834,
+            "label": "Belfast"
+        },
+        {
+            "value": 88,
+            "label": "Berkshire"
+        },
+        {
+            "value": 90,
+            "label": "Blaenau Gwent"
+        },
+        {
+            "value": 3788,
+            "label": "Borders"
+        },
+        {
+            "value": 3835,
+            "label": "Bridgend"
+        },
+        {
+            "value": 3474,
+            "label": "Bristol"
+        },
+        {
+            "value": 94,
+            "label": "Buckinghamshire"
+        },
+        {
+            "value": 3824,
+            "label": "Caerphilly"
+        },
+        {
+            "value": 97,
+            "label": "Caithness"
+        },
+        {
+            "value": 98,
+            "label": "Cambridgeshire"
+        },
+        {
+            "value": 3818,
+            "label": "Cardiff"
+        },
+        {
+            "value": 100,
+            "label": "Carmarthenshire"
+        },
+        {
+            "value": 3827,
+            "label": "Carrickfergus"
+        },
+        {
+            "value": 102,
+            "label": "Castlereagh"
+        },
+        {
+            "value": 3825,
+            "label": "Ceredigion"
+        },
+        {
+            "value": 3826,
+            "label": "Cheshire"
+        },
+        {
+            "value": 105,
+            "label": "Clackmannanshire"
+        },
+        {
+            "value": 3829,
+            "label": "Coleraine"
+        },
+        {
+            "value": 3819,
+            "label": "Conwy"
+        },
+        {
+            "value": 3828,
+            "label": "Cookstown"
+        },
+        {
+            "value": 110,
+            "label": "Cornwall"
+        },
+        {
+            "value": 3822,
+            "label": "County Durham"
+        },
+        {
+            "value": 3821,
+            "label": "County Londonderry"
+        },
+        {
+            "value": 111,
+            "label": "Craigavon"
+        },
+        {
+            "value": 113,
+            "label": "Cumbria"
+        },
+        {
+            "value": 114,
+            "label": "Denbighshire"
+        },
+        {
+            "value": 115,
+            "label": "Derbyshire"
+        },
+        {
+            "value": 117,
+            "label": "Devon"
+        },
+        {
+            "value": 118,
+            "label": "Dorset"
+        },
+        {
+            "value": 3812,
+            "label": "Dumbartonshire"
+        },
+        {
+            "value": 121,
+            "label": "Dumfries and Galloway"
+        },
+        {
+            "value": 3820,
+            "label": "Dungannon and South Tyrone"
+        },
+        {
+            "value": 3813,
+            "label": "East Lothian"
+        },
+        {
+            "value": 3815,
+            "label": "East Sussex"
+        },
+        {
+            "value": 127,
+            "label": "East Yorkshire"
+        },
+        {
+            "value": 129,
+            "label": "Essex"
+        },
+        {
+            "value": 3816,
+            "label": "Fermanagh and Omagh"
+        },
+        {
+            "value": 131,
+            "label": "Fife"
+        },
+        {
+            "value": 132,
+            "label": "Flintshire"
+        },
+        {
+            "value": 3817,
+            "label": "Glasgow"
+        },
+        {
+            "value": 134,
+            "label": "Gloucestershire"
+        },
+        {
+            "value": 3809,
+            "label": "Greater London"
+        },
+        {
+            "value": 3811,
+            "label": "Greater Manchester"
+        },
+        {
+            "value": 138,
+            "label": "Guernsey"
+        },
+        {
+            "value": 140,
+            "label": "Gwynedd"
+        },
+        {
+            "value": 143,
+            "label": "Hampshire"
+        },
+        {
+            "value": 145,
+            "label": "Herefordshire"
+        },
+        {
+            "value": 146,
+            "label": "Herm"
+        },
+        {
+            "value": 147,
+            "label": "Hertfordshire"
+        },
+        {
+            "value": 148,
+            "label": "Highland"
+        },
+        {
+            "value": 151,
+            "label": "Inverness-shire"
+        },
+        {
+            "value": 74,
+            "label": "Isle of Anglesey"
+        },
+        {
+            "value": 3051,
+            "label": "Isle of Man"
+        },
+        {
+            "value": 152,
+            "label": "Isle of Wight"
+        },
+        {
+            "value": 153,
+            "label": "Jersey"
+        },
+        {
+            "value": 154,
+            "label": "Kent"
+        },
+        {
+            "value": 155,
+            "label": "Kincardineshire"
+        },
+        {
+            "value": 157,
+            "label": "Kirkcudbrightshire"
+        },
+        {
+            "value": 159,
+            "label": "Lancashire"
+        },
+        {
+            "value": 3810,
+            "label": "Larne"
+        },
+        {
+            "value": 3807,
+            "label": "Leicestershire"
+        },
+        {
+            "value": 3808,
+            "label": "Limavady"
+        },
+        {
+            "value": 163,
+            "label": "Lincolnshire"
+        },
+        {
+            "value": 3806,
+            "label": "Lisburn and Castlereagh"
+        },
+        {
+            "value": 3800,
+            "label": "Magherafelt"
+        },
+        {
+            "value": 168,
+            "label": "Merseyside"
+        },
+        {
+            "value": 3802,
+            "label": "Merthyr Tydfil"
+        },
+        {
+            "value": 171,
+            "label": "Midlothian"
+        },
+        {
+            "value": 172,
+            "label": "Monmouthshire"
+        },
+        {
+            "value": 3801,
+            "label": "Morayshire"
+        },
+        {
+            "value": 3803,
+            "label": "Moyle"
+        },
+        {
+            "value": 176,
+            "label": "Nairn"
+        },
+        {
+            "value": 3805,
+            "label": "Neath Port Talbot"
+        },
+        {
+            "value": 3795,
+            "label": "Newport"
+        },
+        {
+            "value": 3804,
+            "label": "Newry, Mourne and Down"
+        },
+        {
+            "value": 180,
+            "label": "Norfolk"
+        },
+        {
+            "value": 3832,
+            "label": "North Down and Ards"
+        },
+        {
+            "value": 4546,
+            "label": "North Lanarkshire"
+        },
+        {
+            "value": 3796,
+            "label": "North Yorkshire"
+        },
+        {
+            "value": 183,
+            "label": "Northamptonshire"
+        },
+        {
+            "value": 184,
+            "label": "Northumberland"
+        },
+        {
+            "value": 3794,
+            "label": "Nottinghamshire"
+        },
+        {
+            "value": 186,
+            "label": "Omagh"
+        },
+        {
+            "value": 3797,
+            "label": "Orkney Islands"
+        },
+        {
+            "value": 187,
+            "label": "Oxfordshire"
+        },
+        {
+            "value": 189,
+            "label": "Pembrokeshire"
+        },
+        {
+            "value": 3798,
+            "label": "Perth and Kinross"
+        },
+        {
+            "value": 190,
+            "label": "Perthshire and Kinross"
+        },
+        {
+            "value": 191,
+            "label": "Powys"
+        },
+        {
+            "value": 3799,
+            "label": "Redcar and Cleveland"
+        },
+        {
+            "value": 193,
+            "label": "Renfrewshire"
+        },
+        {
+            "value": 194,
+            "label": "Rhondda Cynon Taff"
+        },
+        {
+            "value": 197,
+            "label": "Rutland"
+        },
+        {
+            "value": 198,
+            "label": "Sark"
+        },
+        {
+            "value": 3787,
+            "label": "Shetland Islands"
+        },
+        {
+            "value": 3789,
+            "label": "Shropshire"
+        },
+        {
+            "value": 202,
+            "label": "Somerset"
+        },
+        {
+            "value": 4547,
+            "label": "South Lanarkshire"
+        },
+        {
+            "value": 204,
+            "label": "South Yorkshire"
+        },
+        {
+            "value": 205,
+            "label": "Staffordshire"
+        },
+        {
+            "value": 3790,
+            "label": "Stirlingshire"
+        },
+        {
+            "value": 207,
+            "label": "Strabane"
+        },
+        {
+            "value": 209,
+            "label": "Suffolk"
+        },
+        {
+            "value": 210,
+            "label": "Surrey"
+        },
+        {
+            "value": 211,
+            "label": "Sussex"
+        },
+        {
+            "value": 212,
+            "label": "Sutherland"
+        },
+        {
+            "value": 213,
+            "label": "Swansea"
+        },
+        {
+            "value": 3791,
+            "label": "Torfaen"
+        },
+        {
+            "value": 216,
+            "label": "Tyne and Wear"
+        },
+        {
+            "value": 3792,
+            "label": "Vale of Glamorgan"
+        },
+        {
+            "value": 219,
+            "label": "Warwickshire"
+        },
+        {
+            "value": 221,
+            "label": "West Lothian"
+        },
+        {
+            "value": 222,
+            "label": "West Midlands"
+        },
+        {
+            "value": 3786,
+            "label": "West Sussex"
+        },
+        {
+            "value": 224,
+            "label": "West Yorkshire"
+        },
+        {
+            "value": 3814,
+            "label": "Western Isles"
+        },
+        {
+            "value": 228,
+            "label": "Wiltshire"
+        },
+        {
+            "value": 229,
+            "label": "Worcestershire"
+        },
+        {
+            "value": 3793,
+            "label": "Wrexham"
+        }
+    ]
+}


### PR DESCRIPTION
Options responses are not structured in uniform with the rest of the API. All others return with count and total, along with data. Since responses for options calls do not distinguish these variables, I created a new class that does not extend StandardListWrapper.

Additionally, Option objects are returned as a data array, thus it is parsed as an "Option[]" array first, and then convert to a List.