### PR TITLE
public association class constructors

### DIFF
--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/AppointmentAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/AppointmentAssociations.java
@@ -22,7 +22,7 @@ public class AppointmentAssociations implements EntityAssociations<Appointment> 
 
     private static final AppointmentAssociations INSTANCE = new AppointmentAssociations();
 
-    private AppointmentAssociations() {
+    public AppointmentAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/BranchAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/BranchAssociations.java
@@ -24,7 +24,7 @@ public class BranchAssociations implements EntityAssociations<Branch> {
 
     private static final BranchAssociations INSTANCE = new BranchAssociations();
 
-    private BranchAssociations() {
+    public BranchAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/CandidateAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/CandidateAssociations.java
@@ -42,7 +42,7 @@ public final class CandidateAssociations implements EntityAssociations<Candidate
     private List<AssociationField<Candidate, ? extends BullhornEntity>> allAssociations;
     private static final CandidateAssociations INSTANCE = new CandidateAssociations();
 
-    private CandidateAssociations() {
+    public CandidateAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/CategoryAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/CategoryAssociations.java
@@ -23,7 +23,7 @@ public final class CategoryAssociations implements EntityAssociations<Category> 
     private List<AssociationField<Category, ? extends BullhornEntity>> allAssociations;
     private final static CategoryAssociations INSTANCE = new CategoryAssociations();
 
-    private CategoryAssociations() {
+    public CategoryAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/ClientContactAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/ClientContactAssociations.java
@@ -41,7 +41,7 @@ public final class ClientContactAssociations implements EntityAssociations<Clien
 
     private static final ClientContactAssociations INSTANCE = new ClientContactAssociations();
 
-    private ClientContactAssociations() {
+    public ClientContactAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/ClientCorporationAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/ClientCorporationAssociations.java
@@ -64,7 +64,7 @@ public final class ClientCorporationAssociations implements EntityAssociations<C
     private final AssociationField<ClientCorporation, ClientCorporationCustomObjectInstance34> customObject34s = instantiateAssociationField("customObject34s", ClientCorporationCustomObjectInstance34.class);
     private final AssociationField<ClientCorporation, ClientCorporationCustomObjectInstance35> customObject35s = instantiateAssociationField("customObject35s", ClientCorporationCustomObjectInstance35.class);
 
-    private ClientCorporationAssociations() {
+    public ClientCorporationAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/ClientCorporationCertificationAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/ClientCorporationCertificationAssociations.java
@@ -16,7 +16,7 @@ public final class ClientCorporationCertificationAssociations implements EntityA
     private List<AssociationField<ClientCorporationCertification, ? extends BullhornEntity>> allAssociations;
     private static final ClientCorporationCertificationAssociations INSTANCE = new ClientCorporationCertificationAssociations();
 
-    private ClientCorporationCertificationAssociations() {
+    public ClientCorporationCertificationAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/CorporateUserAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/CorporateUserAssociations.java
@@ -27,7 +27,7 @@ public final class CorporateUserAssociations implements EntityAssociations<Corpo
     private List<AssociationField<CorporateUser, ? extends BullhornEntity>> allAssociations;
     private static final CorporateUserAssociations INSTANCE = new CorporateUserAssociations();
 
-    private CorporateUserAssociations() {
+    public CorporateUserAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/DistributionListAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/DistributionListAssociations.java
@@ -23,7 +23,7 @@ public final class DistributionListAssociations implements EntityAssociations<Di
 
     private static final DistributionListAssociations INSTANCE = new DistributionListAssociations();
 
-    private DistributionListAssociations() {
+    public DistributionListAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/JobOrderAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/JobOrderAssociations.java
@@ -60,7 +60,7 @@ public final class JobOrderAssociations implements EntityAssociations<JobOrder> 
 
     private static final JobOrderAssociations INSTANCE = new JobOrderAssociations();
 
-    private JobOrderAssociations() {
+    public JobOrderAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/LeadAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/LeadAssociations.java
@@ -29,7 +29,7 @@ public final class LeadAssociations implements EntityAssociations<Lead> {
 
     private static final LeadAssociations INSTANCE = new LeadAssociations();
 
-    private LeadAssociations() {
+    public LeadAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/NoteAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/NoteAssociations.java
@@ -36,7 +36,7 @@ public final class NoteAssociations implements EntityAssociations<Note> {
 
     private static final NoteAssociations INSTANCE = new NoteAssociations();
 
-    private NoteAssociations() {
+    public NoteAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/OpportunityAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/OpportunityAssociations.java
@@ -42,7 +42,7 @@ public final class OpportunityAssociations implements EntityAssociations<Opportu
 
     private static final OpportunityAssociations INSTANCE = new OpportunityAssociations();
 
-    private OpportunityAssociations() {
+    public OpportunityAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/PlacementAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/PlacementAssociations.java
@@ -36,7 +36,7 @@ public final class PlacementAssociations implements EntityAssociations<Placement
     private static final PlacementAssociations INSTANCE = new PlacementAssociations();
     private List<AssociationField<Placement,? extends BullhornEntity>> allAssociations;
 
-    private PlacementAssociations() {
+    public PlacementAssociations() {
         super();
     }
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/TearsheetAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/TearsheetAssociations.java
@@ -25,7 +25,7 @@ public final class TearsheetAssociations implements EntityAssociations<Tearsheet
 	private List<AssociationField<Tearsheet, ? extends BullhornEntity>> allAssociations;
 	private static final TearsheetAssociations INSTANCE = new TearsheetAssociations();
 
-	private TearsheetAssociations() {
+    public TearsheetAssociations() {
 		super();
 	}
 

--- a/src/main/java/com/bullhornsdk/data/model/entity/association/standard/WorkersCompensationAssociations.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/association/standard/WorkersCompensationAssociations.java
@@ -22,7 +22,7 @@ public final class WorkersCompensationAssociations implements EntityAssociations
 	private List<AssociationField<WorkersCompensation, ? extends BullhornEntity>> allAssociations;
 	private static final WorkersCompensationAssociations INSTANCE = new WorkersCompensationAssociations();
 
-	private WorkersCompensationAssociations() {
+    public WorkersCompensationAssociations() {
 		super();
 	}
 


### PR DESCRIPTION
making the constructors of the association classes public. allows for iterating through the associations of a generic entity.