### PR TITLE
Allow login without providing URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,9 @@ Provide your credentials and instantiate StandardBullhornApiRest:
 ```java
         BullhornRestCredentials creds = new BullhornRestCredentials();
 		creds.setPassword("apipassword");
-		creds.setRestAuthorizeUrl("rest.authorizeUrl");
 		creds.setRestClientId("rest.clientId");
 		creds.setRestClientSecret("rest.clientSecret");
-		creds.setRestLoginUrl(env.getProperty("rest.loginUrl");
 		creds.setRestSessionMinutesToLive("rest.sessionMinutesToLive");
-		creds.setRestTokenUrl("rest.tokenUrl");
 		creds.setUsername("apiusername");
 		BullhornData bullhornData = new StandardBullhornData(creds);
 ```
@@ -62,12 +59,9 @@ public class AppConfig {
 
 		RestCredentials creds = new BullhornRestCredentials();
         creds.setPassword("apipassword");
-        creds.setRestAuthorizeUrl("rest.authorizeUrl");
         creds.setRestClientId("rest.clientId");
         creds.setRestClientSecret("rest.clientSecret");
-        creds.setRestLoginUrl(env.getProperty("rest.loginUrl");
         creds.setRestSessionMinutesToLive("rest.sessionMinutesToLive");
-        creds.setRestTokenUrl("rest.tokenUrl");
         creds.setUsername("apiusername");
 		return new StandardBullhornData(creds);
 

--- a/src/main/java/com/bullhornsdk/data/api/helper/RestApiSession.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/RestApiSession.java
@@ -41,6 +41,8 @@ public class RestApiSession {
 	private static final String ACCESS_TOKEN_GRANT_TYPE = "authorization_code";
 
 	private static final String REFRESH_TOKEN_GRANT_TYPE = "refresh_token";
+    private static final String REST_SERVICES_LOGIN_URL = "https://rest.bullhornstaffing.com/rest-services/login";
+    private static final String AUTH_URL = "https://auth.bullhornstaffing.com/oauth/";
 
 	private static Logger log = Logger.getLogger(RestApiSession.class);
 
@@ -123,6 +125,7 @@ public class RestApiSession {
 	private void createSession() {
 		for (int tryNumber = 1; tryNumber <= SESSION_RETRY; tryNumber++) {
 			try {
+			    setCredentialUrls();
 				String authCode = getAuthorizationCode();
 				getAccessToken(authCode);
 				login();
@@ -138,6 +141,12 @@ public class RestApiSession {
 			}
 		}
 	}
+
+	private void setCredentialUrls() {
+        restCredentials.setRestAuthorizeUrl(AUTH_URL + "authorize");
+        restCredentials.setRestTokenUrl(AUTH_URL + "token");
+        restCredentials.setRestLoginUrl(REST_SERVICES_LOGIN_URL);
+    }
 
 	private String getAuthorizationCode() throws RestApiException {
 		String authorizeUrl = restCredentials.getRestAuthorizeUrl();

--- a/src/test/java/com/bullhornsdk/data/api/helper/TestRestApiSession.java
+++ b/src/test/java/com/bullhornsdk/data/api/helper/TestRestApiSession.java
@@ -31,12 +31,9 @@ public class TestRestApiSession extends BaseTest {
 	public void setupTheCredentials() {
 		BullhornRestCredentials creds = new BullhornRestCredentials();
 
-		creds.setRestAuthorizeUrl("https://auth9.bullhornstaffing.com/oauth/authorize");
 		creds.setRestClientId("MY-CLIENT-ID");
 		creds.setRestClientSecret("MY-CLIENT-SECRET");
-		creds.setRestLoginUrl("https://rest9.bullhornstaffing.com/rest-services/login");
 		creds.setRestSessionMinutesToLive("1400");
-		creds.setRestTokenUrl("https://auth9.bullhornstaffing.com/oauth/token");
 		creds.setUsername("MY-USERNAME");
 		creds.setPassword("MY-PASSWORD");
 		this.bullhornRestCredentials = creds;


### PR DESCRIPTION
This removes the need to retrieve oauth and rest_services URLs before attempting to use this SDK.