### PR TITLE
Add missing JsonIgnore in CandidateWorkHistory.salaryType

### DIFF
--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/CandidateWorkHistory.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/CandidateWorkHistory.java
@@ -114,6 +114,7 @@ public class CandidateWorkHistory extends AbstractEntity implements QueryEntity,
 	@JsonProperty("salary2")
 	private BigDecimal salary2;
 
+    @JsonIgnore
 	@Size(max = 20)
 	private String salaryType;
 


### PR DESCRIPTION
This prevents the JSON deserializer from trying to use the setter, which will fail if the field is configured as a multi-value  (i.e it tries to deserialize an array into a string).

This is a quick fix  for this entity, but ideally a revision should be made for all other entities which hold String fields, which may be used as multi-value fields.