### PR TITLE
Adding support for InvoiceStatementHistory entity

### DIFF
--- a/src/main/java/com/bullhornsdk/data/api/mock/MockDataLoader.groovy
+++ b/src/main/java/com/bullhornsdk/data/api/mock/MockDataLoader.groovy
@@ -541,6 +541,7 @@ public class MockDataLoader {
         entityFiles.put(EarnCodeGroup.class, "paybill/earncodegroup-data.txt");
         entityFiles.put(InvoiceStatement.class, "paybill/invoicestatement-data.txt");
         entityFiles.put(InvoiceStatementBatch.class, "paybill/invoicestatementbatch-data.txt");
+        entityFiles.put(InvoiceStatementHistory.class, "paybill/invoicestatementhistory-data.txt");
         entityFiles.put(InvoiceStatementDiscount.class, "paybill/invoicestatementdiscount-data.txt");
         entityFiles.put(InvoiceStatementExportBatch.class, "paybill/invoicestatementexportbatch-data.txt");
         entityFiles.put(InvoiceStatementLineItem.class, "paybill/invoicestatementlineitem-data.txt");

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/paybill/invoice/InvoiceStatementHistory.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/paybill/invoice/InvoiceStatementHistory.java
@@ -1,0 +1,118 @@
+package com.bullhornsdk.data.model.entity.core.paybill.invoice;
+
+import com.bullhornsdk.data.model.entity.core.standard.CorporateUser;
+import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
+import com.bullhornsdk.data.model.entity.core.type.QueryEntity;
+import com.bullhornsdk.data.util.ReadOnly;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import org.joda.time.DateTime;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonRootName(value = "data")
+@JsonPropertyOrder({"id", "invoiceStatement", "modifyingUser", "dateAdded", "status", "comments"})
+public class InvoiceStatementHistory extends AbstractEntity implements QueryEntity {
+    private Integer id;
+    private InvoiceStatement invoiceStatement;
+    private CorporateUser modifyingUser;
+    private DateTime dateAdded;
+    private String status;
+    private String comments;
+
+    @Override
+    @JsonProperty("id")
+    public Integer getId() {
+        return id;
+    }
+
+    @ReadOnly
+    @Override
+    @JsonProperty("id")
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @JsonProperty("invoiceStatement")
+    public InvoiceStatement getInvoiceStatement() {
+        return invoiceStatement;
+    }
+
+    @JsonProperty("invoiceStatement")
+    public void setInvoiceStatement(InvoiceStatement invoiceStatement) {
+        this.invoiceStatement = invoiceStatement;
+    }
+
+    @JsonProperty("modifyingUser")
+    public CorporateUser getModifyingUser() {
+        return modifyingUser;
+    }
+
+    @JsonProperty("modifyingUser")
+    public void setModifyingUser(CorporateUser modifyingUser) {
+        this.modifyingUser = modifyingUser;
+    }
+
+    @JsonProperty("dateAdded")
+    public DateTime getDateAdded() {
+        return dateAdded;
+    }
+
+    @JsonProperty("dateAdded")
+    public void setDateAdded(DateTime dateAdded) {
+        this.dateAdded = dateAdded;
+    }
+
+    @JsonProperty("status")
+    public String getStatus() {
+        return status;
+    }
+
+    @JsonProperty("status")
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @JsonProperty("comments")
+    public String getComments() {
+        return comments;
+    }
+
+    @JsonProperty("comments")
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InvoiceStatementHistory that = (InvoiceStatementHistory) o;
+        return Objects.equals(id, that.id) &&
+            Objects.equals(invoiceStatement, that.invoiceStatement) &&
+            Objects.equals(modifyingUser, that.modifyingUser) &&
+            Objects.equals(dateAdded, that.dateAdded) &&
+            Objects.equals(status, that.status) &&
+            Objects.equals(comments, that.comments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, invoiceStatement, modifyingUser, dateAdded, status, comments);
+    }
+
+    @Override
+    public String toString() {
+        return "InvoiceStatementHistory{" +
+            "id=" + id +
+            ", invoiceStatement=" + invoiceStatement +
+            ", modifyingUser=" + modifyingUser +
+            ", dateAdded=" + dateAdded +
+            ", status='" + status + '\'' +
+            ", comments='" + comments + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/com/bullhornsdk/data/model/enums/BullhornEntityInfo.java
+++ b/src/main/java/com/bullhornsdk/data/model/enums/BullhornEntityInfo.java
@@ -346,6 +346,7 @@ public enum BullhornEntityInfo {
     INVOICE_STATEMENT_DISCOUNT_RATE("InvoiceStatementDiscountRate", InvoiceStatementDiscountRate.class, InvoiceStatementDiscountRateWrapper.class, InvoiceStatementDiscountRateListWrapper.class, null, null),
     INVOICE_STATEMENT_SALES_TAX_RATE("InvoiceStatementSalesTaxRate", InvoiceStatementSalesTaxRate.class, InvoiceStatementSalesTaxRateWrapper.class, InvoiceStatementSalesTaxRateListWrapper.class, null, null),
     INVOICE_STATEMENT_SURCHARGE_RATE("InvoiceStatementSurchargeRate", InvoiceStatementSurchargeRate.class, InvoiceStatementSurchargeRateWrapper.class, InvoiceStatementSurchargeRateListWrapper.class, null, null),
+    INVOICE_STATEMENT_HISTORY("InvoiceStatementHistory", InvoiceStatementHistory.class, InvoiceStatementHistoryWrapper.class, InvoiceStatementHistoryListWrapper.class, null, null),
     SALES_TAX_RATE("SalesTaxRate", SalesTaxRate.class, SalesTaxRateWrapper.class, SalesTaxRateListWrapper.class, "SalesTaxRateEditHistory", "SalesTaxRateEditHistoryFieldChange"),
     SALES_TAX_RATE_VERSION("SalesTaxRateVersion", SalesTaxRateVersion.class, SalesTaxRateVersionWrapper.class, SalesTaxRateVersionListWrapper.class, null, null),
     SURCHARGE_RATE("SurchargeRate", SurchargeRate.class, SurchargeRateWrapper.class, SurchargeRateListWrapper.class, null, null),

--- a/src/main/java/com/bullhornsdk/data/model/response/list/InvoiceStatementHistoryListWrapper.java
+++ b/src/main/java/com/bullhornsdk/data/model/response/list/InvoiceStatementHistoryListWrapper.java
@@ -1,0 +1,11 @@
+package com.bullhornsdk.data.model.response.list;
+
+import com.bullhornsdk.data.model.entity.core.paybill.invoice.InvoiceStatementHistory;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"data", "count", "start"})
+public class InvoiceStatementHistoryListWrapper extends StandardListWrapper<InvoiceStatementHistory> {
+
+}

--- a/src/main/java/com/bullhornsdk/data/model/response/single/InvoiceStatementHistoryWrapper.java
+++ b/src/main/java/com/bullhornsdk/data/model/response/single/InvoiceStatementHistoryWrapper.java
@@ -1,0 +1,6 @@
+package com.bullhornsdk.data.model.response.single;
+
+import com.bullhornsdk.data.model.entity.core.paybill.invoice.InvoiceStatementHistory;
+
+public class InvoiceStatementHistoryWrapper extends StandardWrapper<InvoiceStatementHistory> {
+}

--- a/src/test/java/com/bullhornsdk/data/TestEntities.java
+++ b/src/test/java/com/bullhornsdk/data/TestEntities.java
@@ -141,6 +141,8 @@ public class TestEntities {
 
     private Integer invoiceStatementDistributionBatchId;
 
+    private Integer invoiceStatementHistoryId;
+
     public TestEntities() {
         super();
         this.appointmentId = 1;
@@ -272,6 +274,8 @@ public class TestEntities {
         this.invoiceStatementId = 1;
 
         this.invoiceStatementDistributionBatchId = 1;
+
+        this.invoiceStatementHistoryId = 1;
     }
 
     public Integer getAppointmentId() {
@@ -794,6 +798,14 @@ public class TestEntities {
         this.invoiceStatementId = invoiceStatementId;
     }
 
+    public Integer getInvoiceStatementHistoryId() {
+        return invoiceStatementHistoryId;
+    }
+
+    public void setInvoiceStatementHistoryId(Integer invoiceStatementHistoryId) {
+        this.invoiceStatementHistoryId = invoiceStatementHistoryId;
+    }
+
     @Override
     public String toString() {
         return "TestEntities{" +
@@ -862,6 +874,7 @@ public class TestEntities {
             ", invoiceStatementBatchId=" + invoiceStatementBatchId +
             ", invoiceStatementId=" + invoiceStatementId +
             ", invoiceStatementDistributionBatchId=" + invoiceStatementDistributionBatchId +
+            ", invoiceStatementHistoryId=" + invoiceStatementHistoryId +
             '}';
     }
 }

--- a/src/test/java/com/bullhornsdk/data/TestStandardBullhornApiRest.java
+++ b/src/test/java/com/bullhornsdk/data/TestStandardBullhornApiRest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import com.bullhornsdk.data.model.entity.core.onboarding365.forms.FederalTaxForm;
 import com.bullhornsdk.data.model.entity.core.onboarding365.forms.LocalTaxForm;
 import com.bullhornsdk.data.model.entity.core.onboarding365.forms.StateTaxForm;
+import com.bullhornsdk.data.model.entity.core.paybill.invoice.InvoiceStatementHistory;
 import com.bullhornsdk.data.model.entity.core.standard.*;
 import org.apache.log4j.Logger;
 import org.junit.Test;
@@ -751,6 +752,14 @@ public class TestStandardBullhornApiRest extends BaseTest {
 
         assertNotNull("JobShift is null", entity);
 
+    }
+
+    @Test
+    public void testFindInvoiceStatementHistory() {
+
+        InvoiceStatementHistory entity = bullhornData.findEntity(InvoiceStatementHistory.class, testEntities.getInvoiceStatementHistoryId(), getFieldSet());
+
+        assertNotNull("InvoiceStatementHistory is null", entity);
     }
 
     private Set<String> getFieldSet() {

--- a/src/test/java/com/bullhornsdk/data/TestStandardBullhornApiRestQuery.java
+++ b/src/test/java/com/bullhornsdk/data/TestStandardBullhornApiRestQuery.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import com.bullhornsdk.data.model.entity.core.onboarding365.forms.FederalTaxForm;
 import com.bullhornsdk.data.model.entity.core.onboarding365.forms.LocalTaxForm;
 import com.bullhornsdk.data.model.entity.core.onboarding365.forms.StateTaxForm;
+import com.bullhornsdk.data.model.entity.core.paybill.invoice.InvoiceStatementHistory;
 import com.bullhornsdk.data.model.entity.core.standard.*;
 import com.bullhornsdk.data.model.entity.file.*;
 import org.apache.log4j.Logger;
@@ -567,6 +568,13 @@ public class TestStandardBullhornApiRestQuery extends BaseTest {
 
         runAssertions("ListWrapper<FederalTaxForm>", wrapper);
 
+    }
+
+    @Test
+    public void testQueryInvoiceStatementHistory() {
+        ListWrapper<InvoiceStatementHistory> wrapper = bullhornData.query(InvoiceStatementHistory.class, where, null, queryParams);
+
+        runAssertions("ListWrapper<InvoiceStatementHistory>", wrapper);
     }
 
 	private <T extends BullhornEntity> void runAssertions(String wrapperName, ListWrapper<T> wrapper) {

--- a/src/test/resources/testdata/rest/paybill/invoicestatementhistory-data.txt
+++ b/src/test/resources/testdata/rest/paybill/invoicestatementhistory-data.txt
@@ -1,0 +1,286 @@
+{
+    "start": 0,
+    "count": 20,
+    "data": [
+        {
+            "id": 1,
+            "invoiceStatement": {
+                "id": 1
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 2,
+            "invoiceStatement": {
+                "id": 2
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 3,
+            "invoiceStatement": {
+                "id": 3
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 4,
+            "invoiceStatement": {
+                "id": 4
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 5,
+            "invoiceStatement": {
+                "id": 5
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 6,
+            "invoiceStatement": {
+                "id": 6
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 7,
+            "invoiceStatement": {
+                "id": 7
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 8,
+            "invoiceStatement": {
+                "id": 8
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 9,
+            "invoiceStatement": {
+                "id": 9
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 10,
+            "invoiceStatement": {
+                "id": 10
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 11,
+            "invoiceStatement": {
+                "id": 11
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 12,
+            "invoiceStatement": {
+                "id": 12
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 13,
+            "invoiceStatement": {
+                "id": 13
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 14,
+            "invoiceStatement": {
+                "id": 14
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 15,
+            "invoiceStatement": {
+                "id": 15
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 16,
+            "invoiceStatement": {
+                "id": 16
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 17,
+            "invoiceStatement": {
+                "id": 17
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 18,
+            "invoiceStatement": {
+                "id": 18
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 19,
+            "invoiceStatement": {
+                "id": 19
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        },
+        {
+            "id": 20,
+            "invoiceStatement": {
+                "id": 20
+            },
+            "modifyingUser": {
+                "id": 2034545,
+                "firstName": "Bullhorn",
+                "lastName": "Support"
+            },
+            "dateAdded": 1665012016937,
+            "status": "Approved",
+            "comments": ""
+        }
+    ]
+}


### PR DESCRIPTION
See Pay and Bill (WFR) Entity Reference Guide and Scripts in Confluence for reference on this entity. It is not described in the Entity Reference.

- Adding support to query InvoiceStatementHistory