### PR TITLE
ARPBE-68: Support for blanking fields through the REST API.

### DIFF
--- a/src/main/groovy/com/bullhornsdk/data/api/mock/MockBullhornData.groovy
+++ b/src/main/groovy/com/bullhornsdk/data/api/mock/MockBullhornData.groovy
@@ -155,6 +155,16 @@ public class MockBullhornData implements BullhornData {
     }
 
     @Override
+    public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity, Set<String> nullBypassFields) {
+
+        CrudResponse response = null;
+
+        response = mockDataHandler.updateEntity(entity, nullBypassFields);
+
+        return (C) response;
+    }
+
+    @Override
     public <C extends CrudResponse, T extends UpdateEntity> List<C> updateMultipleEntities(List<T> entityList) {
         List<C> responseList = new ArrayList<C>();
         entityList.each {

--- a/src/main/groovy/com/bullhornsdk/data/api/mock/MockDataHandler.groovy
+++ b/src/main/groovy/com/bullhornsdk/data/api/mock/MockDataHandler.groovy
@@ -1067,7 +1067,8 @@ public class MockDataHandler {
 
 				Object newValue = descriptor.getReadMethod().invoke(from);
 				if ((newValue != null || fieldsToBypass.contains(descriptor.getName())) && !"id".equals(descriptor.getName())) {
-					descriptor.getWriteMethod().invoke(to, newValue);
+                    // Pass array to invoke method to allow null values
+					descriptor.getWriteMethod().invoke(to, [newValue] as Object[]);
 				}
 
 			}

--- a/src/main/groovy/com/bullhornsdk/data/api/mock/MockDataHandler.groovy
+++ b/src/main/groovy/com/bullhornsdk/data/api/mock/MockDataHandler.groovy
@@ -213,13 +213,17 @@ public class MockDataHandler {
 		return (C) response;
 	}
 
+    public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity) {
+        return updateEntity(entity, Collections.emptySet());
+    }
+
 	/**
 	 * Updates the entity.
 	 *
 	 * @param entity
 	 * @return
 	 */
-	public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity) {
+	public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity, Set<String> nullBypassFields) {
 		Map<Integer, T> currentValues = (Map<Integer, T>) restEntityMap.get(entity.getClass());
 		CrudResponse response = new UpdateResponse();
 		response.setChangedEntityId(entity.getId());
@@ -230,7 +234,7 @@ public class MockDataHandler {
 			throw new RestApiException("No entity of type "+entity.getClass().getSimpleName()+" with id "+entity.getId()+" exists.");
 		}
 		try {
-			updateExistingEntityWithNewNonNullValues(entity, existingEntity);
+			updateExistingEntityWithNewNonNullOrBypassedValues(entity, existingEntity, nullBypassFields);
 		} catch (Exception e) {
 			response.setErrorCode("500");
 			response.setErrorMessage("Error updating entity of type: " + entity.getClass().getSimpleName() + " with id: " + entity.getId());
@@ -1052,7 +1056,7 @@ public class MockDataHandler {
 	 *
 	 */
 
-	private <M> void updateExistingEntityWithNewNonNullValues(M from, M to) throws Exception {
+	private <M> void updateExistingEntityWithNewNonNullOrBypassedValues(M from, M to, Set<String> fieldsToBypass) throws Exception {
 		BeanInfo beanInfo = Introspector.getBeanInfo(to.getClass());
 
 		// Iterate over all the attributes
@@ -1062,7 +1066,7 @@ public class MockDataHandler {
 			if (descriptor.getWriteMethod() != null) {
 
 				Object newValue = descriptor.getReadMethod().invoke(from);
-				if (newValue != null && !"id".equals(descriptor.getName())) {
+				if ((newValue != null || fieldsToBypass.contains(descriptor.getName())) && !"id".equals(descriptor.getName())) {
 					descriptor.getWriteMethod().invoke(to, newValue);
 				}
 

--- a/src/main/java/com/bullhornsdk/data/api/BullhornData.java
+++ b/src/main/java/com/bullhornsdk/data/api/BullhornData.java
@@ -266,6 +266,20 @@ public interface BullhornData {
 
 	public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity);
 
+    /**
+     * Updates an UpdateEntity that is a sub type of BullhornEntity and returns a CrudResponse with info on the update, such as warnings, errors
+     *  and validation errors. Additionally, a set of fields can be passed in order to include them into the payload regardless of whether they have
+     *  null values.
+     *
+     * Please note, the id of the passed in entity cannot be null.
+     *
+     * @param entity the entity to update, must have the id field set.
+     * @param nullBypassFields name of fields that should be included in the payload regardless of whether they have null values
+     *
+     * @return an UpdateResponse with updated entity information
+     */
+    public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity, Set<String> nullBypassFields);
+
 	/**
 	 * Same as updateEntity, but handles a list of entities to update.
 	 *

--- a/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
+++ b/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
@@ -347,6 +347,15 @@ public class StandardBullhornData implements BullhornData {
      * {@inheritDoc}
      */
     @Override
+    public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity, Set<String> nullBypassFields) {
+        return this.handleUpdateEntityWithNullBypass(entity, nullBypassFields);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public <C extends CrudResponse, T extends UpdateEntity> List<C> updateMultipleEntities(List<T> entityList) {
         return this.handleMultipleUpdates(entityList);
     }
@@ -1187,6 +1196,32 @@ public class StandardBullhornData implements BullhornData {
     protected <C extends CrudResponse, T extends UpdateEntity> C handleUpdateEntity(T entity) {
         Map<String, String> uriVariables = restUriVariablesFactory.getUriVariablesForEntityUpdate(
                 BullhornEntityInfo.getTypesRestEntityName(entity.getClass()), entity.getId());
+        String url = restUrlFactory.assembleEntityUrlForUpdate();
+
+        CrudResponse response;
+
+        try {
+            String jsonString = restJsonConverter.convertEntityToJsonString(entity);
+            response = this.performPostRequest(url, jsonString, UpdateResponse.class, uriVariables);
+        } catch (HttpStatusCodeException error) {
+            response = restErrorHandler.handleHttpFourAndFiveHundredErrors(new UpdateResponse(), error, entity.getId());
+        }
+
+        return (C) response;
+    }
+
+    /**
+     * Makes the "entity" api call for updating entities, allowing for null bypassing
+     * <p>
+     * HTTP Method: POST
+     *
+     * @param entity
+     * @param nullBypassFields
+     * @return a UpdateResponse
+     */
+    protected <C extends CrudResponse, T extends UpdateEntity> C handleUpdateEntityWithNullBypass(T entity, Set<String> nullBypassFields) {
+        Map<String, String> uriVariables = restUriVariablesFactory.getUriVariablesForEntityUpdate(
+            BullhornEntityInfo.getTypesRestEntityName(entity.getClass()), entity.getId());
         String url = restUrlFactory.assembleEntityUrlForUpdate();
 
         CrudResponse response;

--- a/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
+++ b/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
@@ -1227,7 +1227,7 @@ public class StandardBullhornData implements BullhornData {
         CrudResponse response;
 
         try {
-            String jsonString = restJsonConverter.convertEntityToJsonString(entity);
+            String jsonString = restJsonConverter.convertEntityToJsonString(entity, nullBypassFields);
             response = this.performPostRequest(url, jsonString, UpdateResponse.class, uriVariables);
         } catch (HttpStatusCodeException error) {
             response = restErrorHandler.handleHttpFourAndFiveHundredErrors(new UpdateResponse(), error, entity.getId());

--- a/src/main/java/com/bullhornsdk/data/api/helper/RestJsonConverter.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/RestJsonConverter.java
@@ -1,9 +1,6 @@
 package com.bullhornsdk.data.api.helper;
 
-import java.io.IOException;
-
-import org.apache.log4j.Logger;
-
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.exception.RestMappingException;
 import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
 import com.fasterxml.jackson.core.JsonParseException;
@@ -12,7 +9,14 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 
 public class RestJsonConverter {
 
@@ -36,32 +40,32 @@ public class RestJsonConverter {
 
     /**
      * Create the ObjectMapper that deserializes entity to json String.
-     * 
+     *
      * Registers the JodaModule to convert DateTime so-called epoch timestamp (number of milliseconds since January 1st, 1970,
      * UTC)
-     * 
+     *
      * @return
      */
     private ObjectMapper createObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JodaModule());
         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+        mapper.setFilterProvider(createFieldFilter(Collections.emptySet()));
         return mapper;
     }
 
     /**
      * Creates the ObjectMapper that serializes json to entity. Wraps the root (most often "data").
-     * 
+     *
      * See @JsonRootName on the RestEntities
-     * 
+     *
      * @return
      */
     private ObjectMapper createObjectMapperWithRootUnWrap() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
         mapper.addHandler(new CustomDeserializationProblemHandler());
-       
-        
+        mapper.setFilterProvider(createFieldFilter(Collections.emptySet()));
         mapper.registerModule(new JodaModule());
         return mapper;
     }
@@ -69,7 +73,7 @@ public class RestJsonConverter {
     /**
      * Converts a jsonString to an object of type T. Unwraps from root, most often this means that the "data" tag is ignored and
      * that the entity is created from within that data tag.
-     * 
+     *
      * @param jsonString
      *            the returned json from the api call.
      * @param type
@@ -99,7 +103,7 @@ public class RestJsonConverter {
 
     /**
      * Takes a BullhornEntity and converts it to a String in json format.
-     * 
+     *
      * @param entity
      *            a BullhornEntity
      * @return the jsonString
@@ -112,5 +116,27 @@ public class RestJsonConverter {
             log.error("Error deserializing entity of type" + entity.getClass() + " to jsonString.", e);
         }
         return jsonString;
+    }
+
+    /**
+     * Takes a BullhornEntity and converts it to a String in json format, optionally including null values.
+     *
+     * @param entity
+     *            a BullhornEntity
+     * @param nullBypassFields fields to include regardless of whether they are null.
+     * @return the jsonString
+     */
+    public <T extends BullhornEntity> String convertEntityToJsonString(T entity, Set<String> nullBypassFields) {
+        String jsonString = "";
+        try {
+            jsonString = objectMapperStandard.writer(createFieldFilter(nullBypassFields)).writeValueAsString(entity);
+        } catch (JsonProcessingException e) {
+            log.error("Error deserializing entity of type" + entity.getClass() + " to jsonString.", e);
+        }
+        return jsonString;
+    }
+
+    private FilterProvider createFieldFilter(Set<String> nullBypassFields) {
+        return new SimpleFilterProvider().addFilter(DynamicNullValueFilter.FILTER_NAME, new DynamicNullValueFilter(nullBypassFields));
     }
 }

--- a/src/main/java/com/bullhornsdk/data/api/helper/json/DynamicNullValueFilter.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/json/DynamicNullValueFilter.java
@@ -1,0 +1,32 @@
+package com.bullhornsdk.data.api.helper.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+
+import java.util.Set;
+
+public class DynamicNullValueFilter extends SimpleBeanPropertyFilter {
+    public final static String FILTER_NAME = "dynamicNullValue";
+    private final Set<String> fieldsToAllow;
+
+    public DynamicNullValueFilter(Set<String> fieldsToAllow) {
+        this.fieldsToAllow = fieldsToAllow;
+    }
+
+    @Override
+    public void serializeAsField(Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer) throws Exception {
+        if (include(writer)) {
+            if (fieldsToAllow.contains(writer.getName()) || hasNotNullValue(pojo, writer)) {
+                writer.serializeAsField(pojo, jgen, provider);
+            }
+        } else if (!jgen.canOmitFields()) {
+            writer.serializeAsOmittedField(pojo, jgen, provider);
+        }
+    }
+
+    private boolean hasNotNullValue(Object pojo, PropertyWriter writer) {
+        return writer.getMember().getValue(pojo) != null;
+    }
+}

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance1.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance1.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance10.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance10.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance11.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance11.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance12.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance12.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance13.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance13.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance14.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance14.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance15.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance15.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance16.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance16.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance17.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance17.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance18.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance18.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance19.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance19.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance2.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance2.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance20.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance20.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance21.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance21.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance22.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance22.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance23.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance23.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance24.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance24.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance25.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance25.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance26.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance26.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance27.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance27.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance28.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance28.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance29.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance29.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance3.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance3.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance30.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance30.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance31.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance31.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance32.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance32.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance33.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance33.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance34.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance34.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance35.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance35.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance4.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance4.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance5.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance5.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance6.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance6.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance7.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance7.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance8.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance8.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance9.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/clientcorporation/ClientCorporationCustomObjectInstance9.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "clientCorporation", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance1.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance1.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance10.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance10.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance2.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance2.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance3.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance3.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance4.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance4.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance5.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance5.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance6.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance6.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance7.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance7.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance8.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance8.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance9.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/joborder/JobOrderCustomObjectInstance9.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "jobOrder", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance1.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance1.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance10.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance10.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance2.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance2.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance3.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance3.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance4.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance4.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance5.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance5.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance6.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance6.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance7.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance7.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance8.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance8.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance9.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/opportunity/OpportunityCustomObjectInstance9.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.opportunity;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "opportunity", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance1.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance1.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance10.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance10.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance11.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance11.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance12.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance12.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance13.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance13.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance14.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance14.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance15.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance15.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance16.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance16.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance17.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance17.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance18.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance18.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance19.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance19.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance2.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance2.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance20.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance20.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance21.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance21.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance22.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance22.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance23.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance23.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance24.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance24.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance25.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance25.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance3.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance3.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance4.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance4.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance5.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance5.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance6.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance6.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance7.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance7.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance8.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance8.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance9.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/person/PersonCustomObjectInstance9.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.person;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "person", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance1.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance1.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance10.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance10.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance2.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance2.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance3.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance3.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance4.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance4.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance5.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance5.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance6.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance6.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance7.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance7.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance8.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance8.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance9.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/customobjectinstances/placement/PlacementCustomObjectInstance9.java
@@ -1,10 +1,11 @@
  package com.bullhornsdk.data.model.entity.core.customobjectinstances.placement;
 
- import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+ import com.fasterxml.jackson.annotation.JsonFilter;
  import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  import com.fasterxml.jackson.annotation.JsonRootName;
 
- @JsonInclude(JsonInclude.Include.NON_NULL)
+ @JsonFilter(DynamicNullValueFilter.FILTER_NAME)
  @JsonRootName(value = "data")
  @JsonPropertyOrder({ "id", "placement", "text1", "text2", "text3", "text4", "text5", "text6", "text7", "text8", "text9", "text10", "text11", "text12", "text13",
          "text14", "text15", "text16", "text17", "text18", "text19", "text20", "int1", "int2", "int3", "int4", "int5", "int6", "int7", "int8", "int9",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/paybill/Location.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/paybill/Location.java
@@ -1,5 +1,6 @@
 package com.bullhornsdk.data.model.entity.core.paybill;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.standard.Candidate;
 import com.bullhornsdk.data.model.entity.core.standard.ClientCorporation;
 import com.bullhornsdk.data.model.entity.core.standard.CorporateUser;
@@ -19,7 +20,7 @@ import java.util.Objects;
 /**
  * Created by fayranne.lipton 4/3/2020
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({"id", "address", "candidate", "clientCorporation",
     "customDate1", "customDate2", "customDate3",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Appointment.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Appointment.java
@@ -1,5 +1,6 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
 import com.bullhornsdk.data.model.entity.core.type.AssociationEntity;
 import com.bullhornsdk.data.model.entity.core.type.CreateEntity;
@@ -12,16 +13,12 @@ import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.model.entity.embedded.OneToManyLinkedId;
 import com.bullhornsdk.data.util.ReadOnly;
 import com.bullhornsdk.data.validation.BullhornUUID;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.*;
 import org.joda.time.DateTime;
 
 import javax.validation.constraints.Size;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "appointmentUUID", "guests", "candidateReference", "childAppointments", "clientContactReference",
         "communicationMethod", "dateAdded", "dateBegin", "dateEnd", "dateLastModified", "description", "isAllDay", "isDeleted",
@@ -121,7 +118,7 @@ public class Appointment extends AbstractEntity implements QueryEntity, UpdateEn
 
     /**
      * Returns the entity with the required fields for an insert set.
-     * 
+     *
      * @return
      */
     public Appointment instantiateForInsert() {

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Candidate.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Candidate.java
@@ -1,6 +1,7 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
 import com.bullhornsdk.data.api.helper.RestOneToManySerializer;
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.person.*;
 import com.bullhornsdk.data.model.entity.core.onboarding.OnboardingReceivedSent;
 import com.bullhornsdk.data.model.entity.core.type.*;
@@ -18,7 +19,7 @@ import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "address", "branch", "businessSectors", "canEnterTime", "categories", "category", "certificationList", "certifications",
 		"clientCorporationBlackList", "clientCorporationWhiteList", "comments", "companyName", "companyURL", "customDate1", "customDate10",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/ClientContact.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/ClientContact.java
@@ -1,6 +1,7 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
 import com.bullhornsdk.data.api.helper.RestOneToManySerializer;
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.person.PersonCustomObjectInstance1;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.person.PersonCustomObjectInstance10;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.person.PersonCustomObjectInstance2;
@@ -25,18 +26,14 @@ import com.bullhornsdk.data.model.entity.embedded.Address;
 import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.model.entity.embedded.OneToManyLinkedId;
 import com.bullhornsdk.data.util.ReadOnly;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.hibernate.validator.constraints.Email;
 import org.joda.time.DateTime;
 
 import javax.validation.constraints.Size;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "address", "branch", "businessSectors", "categories",
 		"category", "certifications", "clientContactID", "clientCorporation",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/ClientCorporation.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/ClientCorporation.java
@@ -1,6 +1,7 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
 import com.bullhornsdk.data.api.helper.RestOneToManySerializer;
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation.ClientCorporationCustomObjectInstance1;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation.ClientCorporationCustomObjectInstance10;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.clientcorporation.ClientCorporationCustomObjectInstance11;
@@ -51,11 +52,7 @@ import com.bullhornsdk.data.model.entity.embedded.Address;
 import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.model.entity.embedded.OneToManyLinkedId;
 import com.bullhornsdk.data.util.ReadOnly;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.joda.time.DateTime;
 
@@ -63,7 +60,7 @@ import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "address", "annualRevenue", "billingAddress", "billingContact", "billingFrequency", "billingPhone",
         "branch", "businessSectorList", "certifications", "requirements", "certificationGroups", "childClientCorporations", "clientContacts",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/JobOrder.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/JobOrder.java
@@ -1,5 +1,7 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import org.joda.time.DateTime;
 
 import com.bullhornsdk.data.model.entity.core.type.AssociationEntity;
@@ -11,11 +13,10 @@ import com.bullhornsdk.data.model.entity.core.type.QueryEntity;
 import com.bullhornsdk.data.model.entity.core.type.SearchEntity;
 import com.bullhornsdk.data.model.entity.core.type.SoftDeleteEntity;
 import com.bullhornsdk.data.model.entity.core.type.UpdateEntity;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({"id", "address", "appointments", "approvedPlacements", "assignedUsers", "benefits", "billRateCategoryID", "billingProfile",
     "bonusPackage", "branch", "branchCode", "businessSectors", "categories", "certificationGroups", "certificationList", "certifications",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/JobSubmission.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/JobSubmission.java
@@ -1,5 +1,6 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.certificationrequirement.JobSubmissionCertificationRequirement;
 import com.bullhornsdk.data.model.entity.core.type.*;
 import com.bullhornsdk.data.model.entity.customfields.CustomFieldsD;
@@ -13,7 +14,7 @@ import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({"id", "appointments", "billRate", "branch", "candidate", "comments",
     "customDate1", "customDate2", "customDate3", "customDate4", "customDate5",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Lead.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Lead.java
@@ -1,5 +1,6 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.type.AssociationEntity;
 import com.bullhornsdk.data.model.entity.core.type.CreateEntity;
 import com.bullhornsdk.data.model.entity.core.type.DateLastModifiedEntity;
@@ -13,18 +14,14 @@ import com.bullhornsdk.data.model.entity.customfields.CustomFieldsB;
 import com.bullhornsdk.data.model.entity.embedded.Address;
 import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.util.ReadOnly;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.*;
 import org.hibernate.validator.constraints.Email;
 import org.joda.time.DateTime;
 
 import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "address", "assignedTo", "branch", "businessSectors", "campaignSource", "candidates", "category", "categories", "clientContacts", "clientCorporation", "comments", "companyName",
 		"companyURL", "conversionSource", "customDate1", "customDate2", "customDate3", "customFloat1", "customFloat2", "customFloat3", "customInt1", "customInt2", "customInt3", "customText1",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Note.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Note.java
@@ -1,5 +1,6 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
 import com.bullhornsdk.data.model.entity.core.type.AssociationEntity;
 import com.bullhornsdk.data.model.entity.core.type.CreateEntity;
@@ -9,17 +10,13 @@ import com.bullhornsdk.data.model.entity.core.type.SoftDeleteEntity;
 import com.bullhornsdk.data.model.entity.core.type.UpdateEntity;
 import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.util.ReadOnly;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.*;
 import org.joda.time.DateTime;
 
 import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "action", "bhTimeStamp", "candidates", "clientContacts", "commentingPerson", "comments", "corporateUsers",
 		"dateAdded", "dateLastModified", "entities", "externalID", "isDeleted", "jobOrder", "jobOrders", "jobShifts" , "leads", "migrateGUID", "minutesSpent",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/NoteEntity.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/NoteEntity.java
@@ -1,16 +1,17 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
 import com.bullhornsdk.data.model.entity.core.type.CreateEntity;
 import com.bullhornsdk.data.model.entity.core.type.HardDeleteEntity;
 import com.bullhornsdk.data.model.entity.core.type.QueryEntity;
 import com.bullhornsdk.data.model.entity.core.type.UpdateEntity;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "note", "targetEntityID", "targetEntityName" })
 public class NoteEntity extends AbstractEntity implements QueryEntity, UpdateEntity, CreateEntity, HardDeleteEntity {

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Opportunity.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Opportunity.java
@@ -1,6 +1,7 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
 import com.bullhornsdk.data.api.helper.RestOneToManySerializer;
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder.JobOrderCustomObjectInstance1;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder.JobOrderCustomObjectInstance10;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.joborder.JobOrderCustomObjectInstance2;
@@ -24,18 +25,14 @@ import com.bullhornsdk.data.model.entity.customfields.CustomFieldsC;
 import com.bullhornsdk.data.model.entity.embedded.Address;
 import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.util.ReadOnly;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.joda.time.DateTime;
 
 import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "actualCloseDate", "address", "appointments", "assignedDate", "assignedUsers", "benefits", "billRateCategoryID", "bonusPackage", "branch", "branchCode", "businessSector",
 		"businessSectors", "campaignSource", "category", "categories", "certifications", "clientContact", "clientCorporation", "committed", "customDate1", "customDate2", "customDate3",
@@ -50,9 +47,9 @@ import java.math.BigDecimal;
 public class Opportunity extends CustomFieldsC implements QueryEntity, SearchEntity, UpdateEntity, CreateEntity, SoftDeleteEntity, FileEntity, AssociationEntity, DateLastModifiedEntity, EditHistoryEntity {
 
 	private BigDecimal luceneScore;
-	
+
 	private Integer id;
-	
+
 	private CorporateUser owner;
 
 	@JsonIgnore
@@ -64,13 +61,13 @@ public class Opportunity extends CustomFieldsC implements QueryEntity, SearchEnt
 
 	@Size(max = 200000)
 	private String description;
-	
+
 	private DateTime estimatedStartDate;
-	
+
 	private BigDecimal estimatedHoursPerWeek;
-	
+
 	private BigDecimal estimatedDuration;
-	
+
 	private BigDecimal salary;
 
 	@JsonIgnore
@@ -88,41 +85,41 @@ public class Opportunity extends CustomFieldsC implements QueryEntity, SearchEnt
 	@JsonIgnore
 	@Size(max = 100)
 	private String branchCode;
-	
+
 	private Boolean isOpen;
-	
+
 	private Address address;
-	
+
 	private DateTime dateAdded;
-	
+
 	private Boolean isDeleted;
-	
+
 	private Integer externalCategoryID;
 
 	@JsonIgnore
 	@Size(max = 200)
 	private String status;
-	
+
 	private ClientContact clientContact;
-	
+
 	private Integer priority;
-	
+
 	private Boolean isClientContact;
-	
+
 	private DateTime dateClientInterview;
-	
+
 	private Integer isPublic;
-	
+
 	private Integer numOpenings;
-	
+
 	private Boolean isExtendable;
-	
+
 	private Integer yearsRequired;
 
 	@JsonIgnore
 	@Size(max = 30)
 	private String externalID;
-	
+
 	private DateTime actualCloseDate;
 
 	@JsonIgnore
@@ -130,26 +127,26 @@ public class Opportunity extends CustomFieldsC implements QueryEntity, SearchEnt
 
 	@JsonIgnore
 	private String salaryRange;
-	
+
 	private Boolean committed;
-	
+
 	private Boolean willRelocate;
 
 	@JsonIgnore
 	@Size(max = 50)
 	private String educationDegree;
-	
+
 	private ClientContact reportToClientContact;
-	
+
 	private DateTime estimatedEndDate;
-	
+
 	private Boolean isInterviewRequired;
-	
+
 	@JsonIgnore
 	private String benefits;
 
 	private String costCenter;
-	
+
 	private String reportTo;
 
 	@JsonIgnore
@@ -163,7 +160,7 @@ public class Opportunity extends CustomFieldsC implements QueryEntity, SearchEnt
 	@JsonIgnore
 	@Size(max = 200000)
 	private String publicDescription;
-	
+
 	private String hoursOfOperation;
 
 	@JsonIgnore
@@ -172,84 +169,84 @@ public class Opportunity extends CustomFieldsC implements QueryEntity, SearchEnt
 
 	@JsonIgnore
 	private String optionsPackage;
-	
+
 	@JsonIgnore
 	private String bonusPackage;
-	
+
 	private OneToMany<JobOrder> jobOrders;
-	
+
 	private ClientCorporation clientCorporation;
-	
+
 	private BigDecimal expectedPayRate;
-	
+
 	private BigDecimal expectedFee;
-	
+
 	private Boolean isClientEditable;
-	
+
 	private CorporateUser responseUser;
-	
+
 	private Integer billRateCategoryID;
-	
+
 	private DateTime expectedCloseDate;
-	
+
 	private DateTime assignedDate;
-	
+
 	private String jobOrderUUID;
 
 	@JsonIgnore
 	@Size(max = 18)
 	private String publishedZip;
-	
+
 	private String migrateGUID;
-	
+
 	private BigDecimal taxRate;
-	
+
 	private Boolean isOpportunity;
-	
+
 	private DateTime dateLastExported;
-	
+
 	private DateTime ignoreUntilDate;
-	
+
 	private OneToMany<Appointment> appointments;
-	
+
 	private OneToMany<Task> tasks;
-	
+
 	private OneToMany<Certification> certifications;
-	
+
 	private OneToMany<CorporateUser> assignedUsers;
-	
+
 	private OneToMany<Category> categories;
-	
+
 	private Category category;
-	
+
 	private BusinessSector businessSector;
-	
+
 	private OneToMany<Specialty> specialties;
-	
+
 	private OneToMany<Skill> skills;
-	
+
 	private OneToMany<Note> notes;
-	
+
 	private OneToMany<BusinessSector> businessSectors;
-	
+
 	private OneToMany<JobSubmission> webResponses;
-	
+
 	private DateTime effectiveDate;
-	
+
 	private Lead lead;
 
 	@JsonIgnore
 	@Size(max = 100)
 	private String campaignSource;
-	
+
 	private BigDecimal markUpPercentage;
-	
+
 	private BigDecimal winProbabilityPercent;
-	
+
 	private BigDecimal dealValue;
-	
+
 	private BigDecimal weightedDealValue;
-	
+
 	private DateTime dateLastModified;
 
 	private OneToMany<Tearsheet> tearsheets;
@@ -273,7 +270,7 @@ public class Opportunity extends CustomFieldsC implements QueryEntity, SearchEnt
     private OneToMany<JobOrderCustomObjectInstance9> customObject9s;
 
     private OneToMany<JobOrderCustomObjectInstance10> customObject10s;
-	
+
 	public Opportunity() {
 		super();
 	}

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Placement.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Placement.java
@@ -1,6 +1,7 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
 import com.bullhornsdk.data.api.helper.RestOneToManySerializer;
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.placement.PlacementCustomObjectInstance1;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.placement.PlacementCustomObjectInstance10;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.placement.PlacementCustomObjectInstance2;
@@ -29,11 +30,7 @@ import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.model.entity.core.paybill.Location;
 import com.bullhornsdk.data.util.ReadOnly;
 import com.bullhornsdk.data.model.response.file.standard.StandardFileAttachment;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.joda.time.DateTime;
 
@@ -41,7 +38,7 @@ import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "appointments", "approvingClientContact", "backupApprovingClientContact", "billingClientContact",
 		"billingFrequency", "billingProfile", "bonusPackage", "branch", "bteSyncStatus", "candidate", "placementCertifications", "changeRequests", "clientBillRate", "clientOvertimeRate",

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Sendout.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Sendout.java
@@ -1,12 +1,13 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
 import com.bullhornsdk.data.model.entity.core.type.CreateEntity;
 import com.bullhornsdk.data.model.entity.core.type.HardDeleteEntity;
 import com.bullhornsdk.data.model.entity.core.type.QueryEntity;
 import com.bullhornsdk.data.model.entity.core.type.UpdateEntity;
 import com.bullhornsdk.data.util.ReadOnly;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRootName;
@@ -16,7 +17,7 @@ import org.joda.time.DateTime;
 import javax.validation.constraints.Size;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "candidate", "clientContact", "clientCorporation", "dateAdded", "email", "isRead", "jobOrder", "jobSubmission",
     "migrateGUID", "user" })

--- a/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Task.java
+++ b/src/main/java/com/bullhornsdk/data/model/entity/core/standard/Task.java
@@ -1,5 +1,6 @@
 package com.bullhornsdk.data.model.entity.core.standard;
 
+import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
 import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
 import com.bullhornsdk.data.model.entity.core.type.CreateEntity;
 import com.bullhornsdk.data.model.entity.core.type.DateLastModifiedEntity;
@@ -10,7 +11,7 @@ import com.bullhornsdk.data.model.entity.core.type.UpdateEntity;
 import com.bullhornsdk.data.model.entity.embedded.OneToManyLinkedId;
 import com.bullhornsdk.data.util.ReadOnly;
 import com.bullhornsdk.data.validation.BullhornUUID;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRootName;
@@ -18,7 +19,7 @@ import org.joda.time.DateTime;
 
 import javax.validation.constraints.Size;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFilter(DynamicNullValueFilter.FILTER_NAME)
 @JsonRootName(value = "data")
 @JsonPropertyOrder({ "id", "candidate", "childTasks", "clientContact", "dateAdded", "dateBegin", "dateCompleted", "dateEnd",
 		"dateLastModified", "description", "isCompleted", "isDeleted", "isPrivate", "isSystemTask", "jobOrder", "jobSubmission", "lead",

--- a/src/test/java/com/bullhornsdk/data/TestStandardBullhornApiRestUpdate.java
+++ b/src/test/java/com/bullhornsdk/data/TestStandardBullhornApiRestUpdate.java
@@ -824,10 +824,30 @@ public class TestStandardBullhornApiRestUpdate<T extends UpdateEntity> extends B
 
     }
 
+    @Test
+    public void testNullValueBypassing() {
+        Candidate entity = bullhornData.findEntity(Candidate.class, testEntities.getLocalTaxFormId(), Sets.newHashSet("id", "phone"));
+
+        this.entity = (T) entity;
+
+        previousValue = entity.getPhone();
+
+        newValue = null;
+
+        //noinspection ConstantValue
+        entity.setPhone(newValue);
+
+        UpdateResponse response = bullhornData.updateEntity(entity, Sets.newHashSet("phone"));
+
+        Candidate updatedEntity = bullhornData.findEntity(Candidate.class, testEntities.getCandidateId(), Sets.newHashSet("id", "phone"));
+        entity.setPhone(previousValue);
+        this.runAssertions(response, newValue, updatedEntity.getPhone());
+    }
+
 	private void runAssertions(UpdateResponse response, String valueShouldBe, String valueIs) {
 		assertNotNull("response is null", response);
 		assertFalse("Validation failed", response.hasValidationErrors());
-		assertTrue("value not updated correctly", valueShouldBe.equals(valueIs));
+        assertEquals("value not updated correctly", valueShouldBe, valueIs);
 	}
 
 

--- a/src/test/java/com/bullhornsdk/data/api/helper/RestJsonConverterTest.java
+++ b/src/test/java/com/bullhornsdk/data/api/helper/RestJsonConverterTest.java
@@ -1,0 +1,35 @@
+package com.bullhornsdk.data.api.helper;
+
+import com.bullhornsdk.data.BaseTest;
+import com.bullhornsdk.data.model.entity.core.standard.Candidate;
+import com.google.common.collect.Sets;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class RestJsonConverterTest extends BaseTest {
+    private Candidate candidate;
+
+    @Before
+    public void setUp() throws Exception {
+        candidate = bullhornData.findEntity(Candidate.class, testEntities.getCandidateId(), Sets.newHashSet("id", "firstName"));
+    }
+
+    @Test
+    public void testConvertEntityToJsonString() {
+        RestJsonConverter jsonConverter = new RestJsonConverter();
+        JSONObject expected = new JSONObject("{\"id\": 1,\"firstName\": \"Want\"}");
+        JSONObject result = new JSONObject(jsonConverter.convertEntityToJsonString(candidate));
+        assertTrue("JSON conversion includes unexpected fields, or does not include expected fields", expected.similar(result));
+    }
+
+    @Test
+    public void testConvertEntityToJsonStringWithNullBypass() {
+        RestJsonConverter jsonConverter = new RestJsonConverter();
+        JSONObject expected = new JSONObject("{\"id\": 1,\"firstName\": \"Want\", \"lastName\": null}");
+        JSONObject result = new JSONObject(jsonConverter.convertEntityToJsonString(candidate, Sets.newHashSet("lastName")));
+        assertTrue("JSON conversion includes unexpected fields, or does not include expected fields", expected.similar(result));
+    }
+}


### PR DESCRIPTION
Added an overload of the `BullhornData.updateEntity` method to allow client code to set certain fields to NULL via the REST API.

To accomplish this, a new Jackson JSON filter has been created (See DynamicNullValueFilter.java) which takes a set of fields that should be included in the update regardless of their value. Users should be careful and make sure any NULL values come from setting the field to NULL explicitly, and not having forgotten to include the field when querying (for example when using `BullhornData.findEntity` / `BullhornData.queryForList` / `BullhornData.searchForList`