### PR TITLE
ARPBE-208: Fix pom.xml to support jre8 and jre17 binaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,20 @@ A Java client library for working with the Bullhorn REST API. Handles authentica
 		<version>1.0</version>
 	</dependency>
 ```
+Note, as of version 2.0 the SDK is built using Java 17 so the default binaries are not compatible with <17 versioned applications.
+If you'd like to use JRE 8 compatible binaries, add the `<classifier>` tag in your dependency:
 
+```xml
+
+	<dependency>
+		<groupId>com.bullhorn</groupId>
+		<artifactId>sdk-rest</artifactId>
+		<version>2.0</version>
+        <classifier>jdk8</classifier>
+	</dependency>
+```
+
+Omission of the `<classifier>` tag will result in Maven downloading the JRE 17 binaries.
 
 ## Basic setup:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Java client library for working with the Bullhorn REST API. Handles authentica
 		<version>1.0</version>
 	</dependency>
 ```
-Note, as of version 2.0 the SDK is built using Java 17 so the default binaries are not compatible with <17 versioned applications.
+Note, as of version 2.0.0 the SDK is built using Java 17 so the default binaries are not compatible with <17 versioned applications.
 If you'd like to use JRE 8 compatible binaries, add the `<classifier>` tag in your dependency:
 
 ```xml
@@ -21,7 +21,7 @@ If you'd like to use JRE 8 compatible binaries, add the `<classifier>` tag in yo
 	<dependency>
 		<groupId>com.bullhorn</groupId>
 		<artifactId>sdk-rest</artifactId>
-		<version>2.0</version>
+		<version>2.0.0</version>
         <classifier>jdk8</classifier>
 	</dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.bullhorn</groupId>
     <artifactId>sdk-rest</artifactId>
-    <version>2.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>Bullhorn REST SDK</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <additionalparam>-Xdoclint:none</additionalparam>
         <coveralls-version>4.2.0</coveralls-version>
         <jacoco-version>0.8.8</jacoco-version>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -265,28 +266,6 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                    <configuration>
-                        <compilerId>groovy-eclipse-compiler</compilerId>
-                        <release>17</release>
-                        <fork>true</fork>
-                    </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-eclipse-compiler</artifactId>
-                            <version>3.6.0-03</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-eclipse-batch</artifactId>
-                            <version>3.0.9-03</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
                     <configuration>
@@ -310,6 +289,79 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <compilerId>groovy-eclipse-compiler</compilerId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile-java8</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>8</release>
+                            <fork>true</fork>
+                            <outputDirectory>${project.build.outputDirectory}_jdk8</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-java17</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>17</release>
+                            <fork>true</fork>
+                            <outputDirectory>${project.build.outputDirectory}_jdk17</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>3.6.0-03</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
+                        <version>3.0.9-03</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>jar-jdk8</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>jdk8</classifier>
+                            <classesDirectory>${project.build.outputDirectory}_jdk8</classesDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jar-jdk17</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>jdk17</classifier>
+                            <classesDirectory>${project.build.outputDirectory}_jdk17</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
In order to allow backwards compatibility for clients using Java8 applications, we are introducing a second execution of the compile phase in the pom, as well as a new packaging executions to account have available jre8 and jre17 bytecodes available, and letting clients chose the bytecode they require by specifying a classifier in their dependency declaration.