### PR TITLE
Adding support to update OneToMany associations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.bullhorn</groupId>
     <artifactId>sdk-rest</artifactId>
-    <version>2.3.3</version>
+    <version>2.3.4</version>
     <packaging>jar</packaging>
 
     <name>Bullhorn REST SDK</name>

--- a/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
+++ b/src/main/java/com/bullhornsdk/data/api/StandardBullhornData.java
@@ -356,7 +356,7 @@ public class StandardBullhornData implements BullhornData {
      */
     @Override
     public <C extends CrudResponse, T extends UpdateEntity> C updateEntity(T entity, Set<String> nullBypassFields) {
-        return this.handleUpdateEntityWithNullBypass(entity, nullBypassFields);
+        return this.handleUpdateEntity(entity, nullBypassFields);
     }
 
 
@@ -1210,20 +1210,7 @@ public class StandardBullhornData implements BullhornData {
      * @return a UpdateResponse
      */
     protected <C extends CrudResponse, T extends UpdateEntity> C handleUpdateEntity(T entity) {
-        Map<String, String> uriVariables = restUriVariablesFactory.getUriVariablesForEntityUpdate(
-            BullhornEntityInfo.getTypesRestEntityName(entity.getClass()), entity.getId());
-        String url = restUrlFactory.assembleEntityUrlForUpdate();
-
-        CrudResponse response;
-
-        try {
-            String jsonString = restJsonConverter.convertEntityToJsonString(entity);
-            response = this.performPostRequest(url, jsonString, UpdateResponse.class, uriVariables);
-        } catch (HttpStatusCodeException error) {
-            response = restErrorHandler.handleHttpFourAndFiveHundredErrors(new UpdateResponse(), error, entity.getId());
-        }
-
-        return (C) response;
+        return handleUpdateEntity(entity, null);
     }
 
     /**
@@ -1231,11 +1218,11 @@ public class StandardBullhornData implements BullhornData {
      * <p>
      * HTTP Method: POST
      *
-     * @param entity
-     * @param nullBypassFields
+     * @param entity The entity to POST to the REST API
+     * @param nullBypassFields The fields that should be allowed null values
      * @return a UpdateResponse
      */
-    protected <C extends CrudResponse, T extends UpdateEntity> C handleUpdateEntityWithNullBypass(T entity, Set<String> nullBypassFields) {
+    protected <C extends CrudResponse, T extends UpdateEntity> C handleUpdateEntity(T entity, Set<String> nullBypassFields) {
         Map<String, String> uriVariables = restUriVariablesFactory.getUriVariablesForEntityUpdate(
             BullhornEntityInfo.getTypesRestEntityName(entity.getClass()), entity.getId());
         String url = restUrlFactory.assembleEntityUrlForUpdate();

--- a/src/main/java/com/bullhornsdk/data/api/helper/RestJsonConverter.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/RestJsonConverter.java
@@ -1,6 +1,8 @@
 package com.bullhornsdk.data.api.helper;
 
 import com.bullhornsdk.data.api.helper.json.DynamicNullValueFilter;
+import com.bullhornsdk.data.api.helper.json.replaceall.ReplaceAllModule;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.bullhornsdk.data.exception.RestMappingException;
@@ -44,6 +46,7 @@ public class RestJsonConverter {
     private ObjectMapper createObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JodaModule());
+        mapper.registerModule(new ReplaceAllModule());
         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
         mapper.setFilterProvider(createFieldFilter(Collections.emptySet()));
         return mapper;
@@ -89,7 +92,10 @@ public class RestJsonConverter {
     public <T extends BullhornEntity> String convertEntityToJsonString(T entity, Set<String> nullBypassFields) {
         String jsonString = "";
         try {
-            jsonString = this.objectMapper.writer(createFieldFilter(nullBypassFields)).writeValueAsString(entity);
+            ObjectWriter writer = nullBypassFields == null
+                ? this.objectMapper.writer()
+                : this.objectMapper.writer(createFieldFilter(nullBypassFields));
+            jsonString = writer.writeValueAsString(entity);
         } catch (JsonProcessingException e) {
             log.error("Error deserializing entity of type" + entity.getClass() + " to jsonString.", e);
         }

--- a/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/OneToManySerializer.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/OneToManySerializer.java
@@ -1,0 +1,24 @@
+package com.bullhornsdk.data.api.helper.json.replaceall;
+
+import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
+import com.bullhornsdk.data.model.entity.embedded.OneToMany;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class OneToManySerializer extends StdSerializer<OneToMany<? extends BullhornEntity>> {
+    protected OneToManySerializer() {
+        super((Class<OneToMany<? extends BullhornEntity>>) (Class<?>) OneToMany.class);
+    }
+
+    @Override
+    public void serialize(OneToMany<? extends BullhornEntity> value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        int[] ids = value.getData().stream().mapToInt(BullhornEntity::getId).toArray();
+        gen.writeStartObject();
+        gen.writeFieldName("replaceAll");
+        gen.writeArray(ids, 0, ids.length);
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllModule.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllModule.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 public class ReplaceAllModule extends SimpleModule {
     public ReplaceAllModule() {
         addSerializer((Class<OneToMany<? extends BullhornEntity>>) (Class<?>) OneToMany.class, new ReplaceAllSerializer());
+
     }
 
     public String getModuleName() {

--- a/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllModule.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllModule.java
@@ -1,0 +1,23 @@
+package com.bullhornsdk.data.api.helper.json.replaceall;
+
+import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
+import com.bullhornsdk.data.model.entity.embedded.OneToMany;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class ReplaceAllModule extends SimpleModule {
+    public ReplaceAllModule() {
+        addSerializer((Class<OneToMany<? extends BullhornEntity>>) (Class<?>) OneToMany.class, new OneToManySerializer());
+    }
+
+    public String getModuleName() {
+        return this.getClass().getSimpleName();
+    }
+
+    public int hashCode() {
+        return this.getClass().hashCode();
+    }
+
+    public boolean equals(Object o) {
+        return this == o;
+    }
+}

--- a/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllModule.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllModule.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class ReplaceAllModule extends SimpleModule {
     public ReplaceAllModule() {
-        addSerializer((Class<OneToMany<? extends BullhornEntity>>) (Class<?>) OneToMany.class, new OneToManySerializer());
+        addSerializer((Class<OneToMany<? extends BullhornEntity>>) (Class<?>) OneToMany.class, new ReplaceAllSerializer());
     }
 
     public String getModuleName() {

--- a/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllSerializer.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/json/replaceall/ReplaceAllSerializer.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
 
-public class OneToManySerializer extends StdSerializer<OneToMany<? extends BullhornEntity>> {
-    protected OneToManySerializer() {
+public class ReplaceAllSerializer extends StdSerializer<OneToMany<? extends BullhornEntity>> {
+    protected ReplaceAllSerializer() {
         super((Class<OneToMany<? extends BullhornEntity>>) (Class<?>) OneToMany.class);
     }
 

--- a/src/main/java/com/bullhornsdk/data/util/ReadOnly.java
+++ b/src/main/java/com/bullhornsdk/data/util/ReadOnly.java
@@ -1,11 +1,16 @@
 package com.bullhornsdk.data.util;
 
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@JacksonAnnotationsInside
+@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 public @interface ReadOnly {
 }

--- a/src/test/java/com/bullhornsdk/data/api/helper/RestJsonConverterTest.java
+++ b/src/test/java/com/bullhornsdk/data/api/helper/RestJsonConverterTest.java
@@ -3,10 +3,7 @@ package com.bullhornsdk.data.api.helper;
 import com.bullhornsdk.data.BaseTest;
 import com.bullhornsdk.data.exception.RestMappingException;
 import com.bullhornsdk.data.model.entity.core.customobjectinstances.placement.PlacementCustomObjectInstance1;
-import com.bullhornsdk.data.model.entity.core.standard.Candidate;
-import com.bullhornsdk.data.model.entity.core.standard.JobSubmission;
-import com.bullhornsdk.data.model.entity.core.standard.Note;
-import com.bullhornsdk.data.model.entity.core.standard.Placement;
+import com.bullhornsdk.data.model.entity.core.standard.*;
 import com.bullhornsdk.data.model.entity.embedded.OneToMany;
 import com.bullhornsdk.data.model.enums.BullhornEntityInfo;
 import com.bullhornsdk.data.model.response.file.standard.StandardFileContent;
@@ -195,5 +192,15 @@ public class RestJsonConverterTest extends BaseTest {
         JSONObject actual = new JSONObject(this.restJsonConverter.convertEntityToJsonString(placement));
         JSONObject expected = new JSONObject("{\"id\": 1, \"customObject1s\": [{\"id\": 2, \"text1\": \"Test\"}]}");
         assertTrue(actual.similar(expected), "OneToMany replaceAll serializer collided with RestOneToManySerializer");
+    }
+
+    @Test
+    public void testReadOnlyAnnotationIgnoresFieldOnSerialization() {
+        JobOrder jobOrder = new JobOrder(1);
+        Placement placement = new Placement(2);
+        jobOrder.setPlacements(new OneToMany<>(placement));
+        JSONObject actual = new JSONObject(this.restJsonConverter.convertEntityToJsonString(jobOrder));
+        JSONObject expected = new JSONObject("{\"id\": 1}");
+        assertTrue(actual.similar(expected), "ReadOnly annotated field was included in payload");
     }
 }

--- a/src/test/java/com/bullhornsdk/data/api/helper/RestJsonConverterTest.java
+++ b/src/test/java/com/bullhornsdk/data/api/helper/RestJsonConverterTest.java
@@ -2,6 +2,7 @@ package com.bullhornsdk.data.api.helper;
 
 import com.bullhornsdk.data.BaseTest;
 import com.bullhornsdk.data.exception.RestMappingException;
+import com.bullhornsdk.data.model.entity.core.customobjectinstances.placement.PlacementCustomObjectInstance1;
 import com.bullhornsdk.data.model.entity.core.standard.Candidate;
 import com.bullhornsdk.data.model.entity.core.standard.JobSubmission;
 import com.bullhornsdk.data.model.entity.core.standard.Note;
@@ -182,5 +183,17 @@ public class RestJsonConverterTest extends BaseTest {
         JSONObject actual = new JSONObject(this.restJsonConverter.convertEntityToJsonString(note));
         JSONObject expected = new JSONObject("{\"placements\": {\"replaceAll\": [1, 2, 3]}, \"id\": 1}");
         assertTrue(actual.similar(expected), "JSON conversion did not conform to replaceAll standard");
+    }
+
+    @Test
+    public void testRestOneToManySerializerDoesNotCollideWithReplaceAll() {
+        Placement placement = new Placement(1);
+        PlacementCustomObjectInstance1 placementCustomObjectInstance1 = new PlacementCustomObjectInstance1();
+        placementCustomObjectInstance1.setId(2);
+        placementCustomObjectInstance1.setText1("Test");
+        placement.setCustomObject1s(new OneToMany<>(placementCustomObjectInstance1));
+        JSONObject actual = new JSONObject(this.restJsonConverter.convertEntityToJsonString(placement));
+        JSONObject expected = new JSONObject("{\"id\": 1, \"customObject1s\": [{\"id\": 2, \"text1\": \"Test\"}]}");
+        assertTrue(actual.similar(expected), "OneToMany replaceAll serializer collided with RestOneToManySerializer");
     }
 }


### PR DESCRIPTION
As of now, we weren't able to update one-to-many associations in a POST call to an entity. This pull requests seeks to provide this functionality for all OneToMany, using Bullhorn's replaceAll syntax, that consists in an array containing the IDs that should replace all entities in an association.