### PR TITLE
Fix incorrect encoding of URIs

### DIFF
--- a/src/main/java/com/bullhornsdk/data/api/helper/RestTemplateFactory.java
+++ b/src/main/java/com/bullhornsdk/data/api/helper/RestTemplateFactory.java
@@ -15,6 +15,7 @@ import org.springframework.http.converter.support.AllEncompassingFormHttpMessage
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 import org.springframework.http.converter.xml.SourceHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 public class RestTemplateFactory {
 
@@ -34,6 +35,9 @@ public class RestTemplateFactory {
 		messageConverters.add(new Jaxb2RootElementHttpMessageConverter());
 		messageConverters.add(new MappingJackson2HttpMessageConverter());
 
-		return new RestTemplate(messageConverters);
+		RestTemplate newTemplate = new RestTemplate(messageConverters);
+		newTemplate.setUriTemplateHandler(new DefaultUriBuilderFactory());
+
+		return newTemplate;
 	}
 }


### PR DESCRIPTION
A bug was introduced with [this commit](970c76a8c57b713e2d75598a0f336d2cfec694e2) which upgraded a major version of the Spring Framework.

The default URI template handler (`URI_COMPONENT`)  in `RestTemplate` would treat variables to URI templates as if they might also contain parts to be expanded. As such, reserved template characters such as `+` and `;` will be handled incorrectly when they are passed into a template.

The new URI template handler (`TEMPLATE_AND_VALUES`) which is the default in the new/preferred `WebClient` fixes this issue by not handling reserved characters incorrectly in template variables.

The bug would for example cause authentication to fail for users with URI template reserved characters in their credentials.

See Spring Framework docs: https://web.archive.org/web/20231214150540/https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-uri-building.html#uri-encoding

The bug could be caught by running the tests in [`TestRestApiSession`](https://github.com/bullhorn/sdk-rest/blob/a375e9479cdd32d18144ad2ecaa3162c608a0b58/src/test/java/com/bullhornsdk/data/api/helper/TestRestApiSession.java) with credentials that contain reserved characters.
Those tests now pass in this case with these changes.