### PR TITLE
Removing WriteOnly restriction on serialization for fields annotated with ReadOnly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.bullhorn</groupId>
     <artifactId>sdk-rest</artifactId>
-    <version>2.3.5</version>
+    <version>2.3.6</version>
     <packaging>jar</packaging>
 
     <name>Bullhorn REST SDK</name>

--- a/src/main/java/com/bullhornsdk/data/util/ReadOnly.java
+++ b/src/main/java/com/bullhornsdk/data/util/ReadOnly.java
@@ -1,8 +1,5 @@
 package com.bullhornsdk.data.util;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -10,7 +7,5 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
-@JacksonAnnotationsInside
-@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 public @interface ReadOnly {
 }


### PR DESCRIPTION
Fixing bug created in v2.3.4 intending to prevent OneToMany fields that should not be updated in BH that were marked as ReadOnly. This stopped serializing IDs for any updates for custom objects or associations that required the ID to be present in a JSON request body.